### PR TITLE
Some debug/log polish, dialogs as table, cli.pl opts, fixes

### DIFF
--- a/MTProto.pm
+++ b/MTProto.pm
@@ -585,8 +585,7 @@ sub _handle_msg
     my ($self, $msg) = @_;
 
     if ($self->{debug}) {
-        AE::log debug => "handle_msg $msg->{seq},$msg->{msg_id}: ";
-        AE::log debug => ref $msg->{object};
+        AE::log debug => "handle_msg $msg->{seq},$msg->{msg_id}: " . ref $msg->{object};
     }
 
     # unpack msg containers
@@ -704,7 +703,7 @@ sub _ack
 {
     my ($self, @msg_ids) = @_;
     my ($package, $filename, $line) = caller;
-    AE::log debug => "ack ", join (",", @msg_ids), "\n" if $self->{debug};
+    AE::log debug => "ack " . join (",", @msg_ids), "\n" if $self->{debug};
 
     my $ack = MTProto::MsgsAck->new( msg_ids => \@msg_ids );
     #$ack->{msg_ids} = \@msg_ids;
@@ -717,6 +716,7 @@ sub resend
     my ($self, $id) = @_;
 
     if (exists $self->{_pending}{$id}){
+        AE::log trace => "resending $id";
         $self->send( $self->{_pending}{$id} );
     }
 }
@@ -732,6 +732,7 @@ sub invoke
     $self->{session}{seq} += 2 unless $is_service;
     $self->send($msg);
     $self->{_pending}{$msg->{msg_id}} = $msg unless $noack;
+    AE::log debug => "invoked $msg->{msg_id} (seq now is $self->{session}{seq})";
     return $msg->{msg_id};
 }
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,18 @@ For CLI application:
 For GUI application (currently minimal almost unusable quick & dirty proof-of-work):
 - Tcl
 - Tkx
+- a Tcl/Tk distribution for these two (out of the box in ActivePerl), see https://tkdocs.com/tutorial/install.html
+
+Not yet used but discussed:
+- Template::Toolkit
+- CBOR::XS
+- DBD::SQLite
 
 ## PREPARE
 - generate parser using yapp: `yapp -m TL -s tl.yp`
 - generate MTProto and Telegram TL packages: `perl tl-gen.pl MTProto res/mtproto.tl` and `perl tl-gen.pl Telegram res/layer78.tl`
+- edit config file to put your own API id/hashm, phone number and possibly proxy
+- if needed, create new session (session.dat for apps) with `auth.pl`: enter to it code sent by SMS or in other session, and then press ^C
+
+## NOTES
+Telegram.pm API is subject to change; do UTF-8 decode yourself.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Not yet used but discussed:
 ## PREPARE
 - generate parser using yapp: `yapp -m TL -s tl.yp`
 - generate MTProto and Telegram TL packages: `perl tl-gen.pl MTProto res/mtproto.tl` and `perl tl-gen.pl Telegram res/layer78.tl`
-- edit config file to put your own API id/hashm, phone number and possibly proxy
+- edit config file to put your own API id/hash, phone number and possibly proxy
 - if needed, create new session (session.dat for apps) with `auth.pl`: enter to it code sent by SMS or in other session, and then press ^C
 
-## NOTES
-Telegram.pm API is subject to change; do UTF-8 decode yourself.
+## NOTES / WARNS
+Telegram.pm API is very unstable and subject to change greatly :)
+
+As scheme is not known to lower-level modules (there are both text strings and byte strings), do UTF-8 decode yourself.
+
+*LEGAL ISSUES*: Publishing API ID/hash in source code prohibited by Telegram License / API Terms of Use. This contradicts to FLOSS principles (may be they plan to ban unofficial clients?), but that is, you won't be able to run Teleperl as-is. See https://github.com/telegramdesktop/tdesktop/blob/dev/docs/api_credentials.md for next steps.

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -85,7 +85,7 @@ sub start
 
     if (defined $self->{_proxy}) {
         # XXX: blocking connect
-        AE::log info => "using proxy " . Dumper [ map{ $self->{_proxy}{$_} } qw/addr port/ ];
+        AE::log info => "using proxy %s:%d", map { $self->{_proxy}{$_} } qw/addr port/;
         my $sock = IO::Socket::Socks->new(
             ProxyAddr => $self->{_proxy}{addr},
             ProxyPort => $self->{_proxy}{port},
@@ -97,7 +97,7 @@ sub start
         $aeh = AnyEvent::Handle->new( fh => $sock );
     }
     else {
-        AE::log info => "not using proxy: " . Dumper [ map{ $self->{_dc}{$_}} qw/addr port/ ];
+        AE::log info => "not using proxy: %s:%d", map{ $self->{_dc}{$_}} qw/addr port/;
         $aeh = AnyEvent::Handle->new( 
             connect => [ map{ $self->{_dc}{$_}} qw/addr port/ ],
             on_connect_error => sub { die "Connection error" }
@@ -147,7 +147,7 @@ sub invoke
     my $req_id;
 
     AE::log info => __LINE__ . " " . ref $query;
-    AE::log debug => Dumper $query if $self->{debug};
+    AE::log trace => Dumper $query if $self->{debug};
     if ($self->{_first}) {
         
         # Wrapper conn
@@ -288,18 +288,18 @@ sub _debug_print_update
 {
     my ($self, $upd) = @_;
 
-    AE::log info => __LINE__ . " " . ref $upd;
+    AE::log debug => __LINE__ . " " . ref $upd;
     
     if ($upd->isa('Telegram::Update::UpdateNewChannelMessage')) {
         my $ch_id = $upd->{message}{to_id}{channel_id};
-        AE::log info => "pts=$upd->{pts}(+$upd->{pts_count}) last=$self->{session}{update_state}{channel_pts}{$ch_id}"
+        AE::log debug => "chan=$ch_id pts=$upd->{pts}(+$upd->{pts_count}) last=$self->{session}{update_state}{channel_pts}{$ch_id}"
             if (exists $upd->{pts});
     }
     elsif ($upd->isa('Telegram::Update::UpdateNewMessage')) {
-        AE::log info => "pts=$upd->{pts}(+$upd->{pts_count}) last=$self->{session}{update_state}{pts}"
+        AE::log debug => "pts=$upd->{pts}(+$upd->{pts_count}) last=$self->{session}{update_state}{pts}"
             if (exists $upd->{pts});
     }
-    AE::log info => "seq=$upd->{seq}" if (exists $upd->{seq} and $upd->{seq} > 0);
+    AE::log debug => "seq=$upd->{seq}" if (exists $upd->{seq} and $upd->{seq} > 0);
 
     #if ($upd->isa('Telegram::Updates')) {
     #    for my $u (@{$upd->{updates}}) {
@@ -314,19 +314,22 @@ sub _handle_update
 
     #say ref $upd;
 
-    #$self->_debug_print_update($upd);
+    $self->_debug_print_update($upd) if $self->{debug};
     
     if ($upd->isa('Telegram::UpdateChannelTooLong')) {
         my $channel = $self->peer_from_id( $upd->{channel_id} );
+        my $local_pts = $self->{session}{update_state}{channel_pts}{$upd->{channel_id}};
+        AE::log warn => "rcvd ChannelTooLong for $upd->{channel_id} but no local pts thus no updates"
+            unless defined $local_pts;
         $self->invoke(
             Telegram::Updates::GetChannelDifference->new(
                 channel => $channel,
                 filter => Telegram::ChannelMessagesFilterEmpty->new,
-                pts => $self->{session}{update_state}{channel_pts}{$upd->{channel_id}},
+                pts => $local_pts,
                 limit => 0
             ),
             sub { $self->_handle_channel_diff( $upd->{channel_id}, @_ ) }
-        ) if defined $channel;
+        ) if defined $channel and $local_pts;
         return;
     }
     
@@ -336,7 +339,7 @@ sub _handle_update
         $upd->isa('Telegram::UpdateEditChannelMessage')
     ) {
         my $chan = exists $upd->{message}{to_id} ? $upd->{message}{to_id}{channel_id} : undef;
-        AE::log info => Dumper $upd unless defined $chan;
+        AE::log warn => "chanmsg without dest ".Dumper $upd unless defined $chan;
         $pts_good = $self->_check_pts( $upd->{pts}, $upd->{pts_count}, $chan
         ) if defined $chan;
     }
@@ -585,6 +588,7 @@ sub _handle_rpc_error
     &{$self->{on_error}}($err) if defined $self->{on_error};
     $self->{error} = $err;
 
+    AE::log warn => "RPC error %s on req %d", $err->{error_message}, $req_id;
     if ($err->{error_message} eq 'USER_DEACTIVATED') {
         $self->{_timer} = undef;
     }
@@ -641,7 +645,7 @@ sub _get_msg_cb
     return sub {
         my $msg = shift;
         AE::log info => __LINE__ . " " . ref $msg;
-        AE::log debug => Dumper $msg->{object} if $self->{debug};
+        AE::log trace => Dumper $msg->{object} if $self->{debug};
 
         # RpcResults
         $self->_handle_rpc_result( $msg->{object} )
@@ -726,7 +730,7 @@ sub send_text_message
 
     $msg->{peer} = $peer;
 
-    AE::log debug => Dumper $msg if defined $self->{debug};
+    AE::log trace => Dumper $msg if defined $self->{debug};
     $self->invoke( $msg ) if defined $peer;
 }
 
@@ -892,11 +896,11 @@ sub peer_name
     my $chats = $self->{session}{chats};
 
     if (exists $users->{$id}) {
-        AE::log debug => "found user ", Dumper($users->{$id}) if $self->{debug};
+        AE::log trace => "found user $id " . Dumper($users->{$id}) if $self->{debug};
         return ($users->{$id}{first_name} // '' ).' '.($users->{$id}{last_name} // '');
     }
     if (exists $chats->{$id}) {
-        AE::log debug => "found chat ", Dumper($chats->{$id}) if $self->{debug};
+        AE::log trace => "found chat $id " . Dumper($chats->{$id}) if $self->{debug};
         return ($chats->{$id}{title} // "chat $id");
     }
     return $id if $noundef;

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -146,9 +146,10 @@ sub invoke
     my ($self, $query, $res_cb) = @_;
     my $req_id;
 
-    AE::log info => __LINE__ . " " . ref $query;
+    AE::log info => "invoke: " . ref $query;
     AE::log trace => Dumper $query if $self->{debug};
     if ($self->{_first}) {
+        AE::log debug => "first, using wrapper";
         
         # Wrapper conn
         my $conn = Telegram::InitConnection->new( 
@@ -182,6 +183,7 @@ sub invoke
         $req_id = $self->{_mt}->invoke( $query );
     }
 
+    AE::log debug => "invoked $req_id for " . ref $query;
     $self->{_req}{$req_id}{query} = $query;
     # store handler for this query result
     $self->{_req}{$req_id}{cb} = $res_cb if defined $res_cb;
@@ -250,7 +252,7 @@ sub _check_pts
         $self->{session}{update_state}{pts};
 
     if (defined $local_pts and $local_pts + $count < $pts) {
-        AE::log debug => "local_pts=$local_pts, pts=$pts, count=$count, channel=$channel" if $self->{debug};
+        AE::log debug => "local_pts=$local_pts, pts=$pts, count=$count, channel=".($channel//"") if $self->{debug};
         if (defined $channel) {
             my $channel_peer = $self->peer_from_id( $channel );
             $self->invoke( Telegram::Updates::GetChannelDifference->new(

--- a/cli.pl
+++ b/cli.pl
@@ -7,9 +7,9 @@ use Teleperl;
 
 my $app = Teleperl->new;
 $app->set_default_command('console');
-$app->run;
+$app->run || warn("non-clean exit, will not save session\n"), exit;
 
-say "quittin..";
+my $sessfile = $app->cache->get('session');
 my $tg = $app->cache->get('tg');
-store( $tg->{session}, 'session.dat' );
-
+say "quittin.. saving to $sessfile";
+store( $tg->{session}, $sessfile );


### PR DESCRIPTION
* change some logging levels to AE::log (more to come) and wrap warn's to AE
* 'set' command to change some opts on the fly
* add more configurable options to CLI app
  - config file: so you could run different accounts with same code/dir
  - session file: ibid, but even save to other file on the fly for experiment
  - debug as two-level, not just bool
* pretty-print received dialog list, with IDs, types, names and unread counts
* ability to mark read partially, up to some id (TDesktop still can't this!)
* bugfix undef value to pack() on ChannelTooLong - means no updates :(

Note that you can set environment variable prior to run like this:

PERL_ANYEVENT_LOG=%filoger=file=cli.log:collect=+%filoger:log=info:filter=note

and then run `cli.pl -dd -v` to have every trace in file while screen no
polluted to be able to use CLI commands... but this currently don't
play well with options, so that's why you may instead need to tweak opts
before and after start, like `set --no-verbose` or something.