### PR TITLE
Add type introspection and CBOR (de)serialising support to autogenera…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Not yet used but discussed:
 
 ## PREPARE
 - generate parser using yapp: `yapp -m TL -s tl.yp`
-- generate MTProto and Telegram TL packages: `perl tl-gen.pl MTProto res/mtproto.tl` and `perl tl-gen.pl Telegram res/layer78.tl`
+- generate MTProto and Telegram TL packages: `perl tl-gen.pl MTProto res/mtproto.tl` and `perl tl-gen.pl Telegram res/layer78-tdesktop.tl`
 - edit config file to put your own API id/hash, phone number and possibly proxy
 - if needed, create new session (session.dat for apps) with `auth.pl`: enter to it code sent by SMS or in other session, and then press ^C
 

--- a/TL/Object.pm
+++ b/TL/Object.pm
@@ -237,4 +237,7 @@ sub unpack_true
     return 1;
 }
 
+package TL::False; sub TO_CBOR { do { bless \(my $o=1), Types::Serialiser::Boolean:: } }
+package TL::True;  sub TO_CBOR { do { bless \(my $o=0), Types::Serialiser::Boolean:: } }
+
 1;

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -53,12 +53,12 @@ use Telegram::InputPeer;
 
 use fields qw(
     _mt _dc _code_cb _app _proxy _timer _first _code_hash _req _lock _flood_timer
-    _queue reconnect session on_update on_error debug keepalive noupdate error );
+    _queue reconnect session on_update on_error on_raw_msg debug keepalive noupdate error );
 
 # args: DC, proxy and stuff
 sub new
 {
-    my @args = qw( on_update on_error noupdate debug keepalive reconnect );
+    my @args = qw( on_update on_error on_raw_msg noupdate debug keepalive reconnect );
     my ($class, %arg) = @_;
     my $self = fields::new( ref $class || $class );
     
@@ -659,6 +659,7 @@ sub _get_msg_cb
         my $msg = shift;
         AE::log info => __LINE__ . " " . ref $msg;
         AE::log trace => Dumper $msg->{object} if $self->{debug};
+        &{$self->{on_raw_msg}}( $msg->{object} ) if $self->{on_raw_msg};
 
         # RpcResults
         $self->_handle_rpc_result( $msg->{object} )


### PR DESCRIPTION
…ted from schema

Also add simplistic raw binary CBOR logger daemon to save every incoming
MTProto messages with class information, to be able to replay later such
logs (e.g. to reproduce bugs, etc.). For now, one could Data::Dumper
these logs by code like this (assuming slurping entire file to $cbor_data):

```
  require $_ for map { $_->{file} } values %Telegram::ObjTable::tl_type;
  require $_ for map { $_->{file} } values %MTProto::ObjTable::tl_type;
  my $cbor = CBOR::XS->new;
  while (length $cbor_data) {
      ($rec, $octets) = $cbor->decode_prefix ($cbor_data);
      say POSIX::strftime("%Y.%m.%d %H:%M:%S ",
        localtime $rec->{time}).Dumper($rec->{data});
      substr($cbor_data, 0, $octets) = '';
  }```