### PR TITLE
GUI: add offline mode and replaying messages from CBOR binary logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Pure perl mtproto/telergam client
 - Config::Tiny
 - AnyEvent
 - IO::Socket::Socks
+- Data::Validate::IP
+- NetAddr::IP
 - Crypt::OpenSSL::Bignum
 - Crypt::OpenSSL::RSA
 - Crypt::OpenSSL::Random
@@ -13,10 +15,12 @@ Pure perl mtproto/telergam client
 - Parse::Yapp
 - Math::Prime::Util
 
-For CLI application:
-- Term::ReadLine::Gnu
+For both interactive application's examples:
 - Getopt::Long::Descriptive
 - Class::Inspector
+
+For CLI application:
+- Term::ReadLine::Gnu
 - Exception::Class
 
 For GUI application (currently minimal almost unusable quick & dirty proof-of-work):
@@ -29,9 +33,11 @@ For GUI application (currently minimal almost unusable quick & dirty proof-of-wo
   * treectrl
   * tklib (ctext tooltip widget)
 
+Not required in minimal run (optional for extra features):
+- CBOR::XS
+
 Not yet used but discussed:
 - Template::Toolkit
-- CBOR::XS
 - DBD::SQLite
 
 ## PREPARE

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -53,12 +53,14 @@ use Telegram::InputPeer;
 
 use fields qw(
     _mt _dc _code_cb _app _proxy _timer _first _code_hash _req _lock _flood_timer
-    _queue reconnect session on_update on_error on_raw_msg debug keepalive noupdate error );
+    _queue reconnect session debug keepalive noupdate error
+    on_update on_error on_raw_msg after_invoke
+);
 
 # args: DC, proxy and stuff
 sub new
 {
-    my @args = qw( on_update on_error on_raw_msg noupdate debug keepalive reconnect );
+    my @args = qw( on_update on_error on_raw_msg after_invoke noupdate debug keepalive reconnect );
     my ($class, %arg) = @_;
     my $self = fields::new( ref $class || $class );
     
@@ -87,35 +89,26 @@ sub start
     my $aeh;
 
     if (defined $self->{_proxy}) {
+        # XXX: blocking connect
         AE::log info => "using proxy %s:%d", map { $self->{_proxy}{$_} } qw/addr port/;
-        $aeh = AnyEvent::Handle->new( 
-            connect => [ map{ $self->{_proxy}{$_}} qw/addr port/ ],
-            on_connect_error => sub { die "Connection error" },
-            on_connect => sub {
-                my $socks = AnyEventSocks->new(
-                    hd => $aeh, 
-                    login => $self->{_proxy}{user},
-                    password => $self->{_proxy}{pass},
-                    cb => sub { $self->_mt($aeh) }
-                );
-                $socks->connect( map{ $self->{_dc}{$_} } qw/addr port/ );
-            }
-        );
+        my $sock = IO::Socket::Socks->new(
+            ProxyAddr => $self->{_proxy}{addr},
+            ProxyPort => $self->{_proxy}{port},
+            ConnectAddr => $self->{_dc}{addr}, 
+            ConnectPort => $self->{_dc}{port},
+            Username => $self->{_proxy}{user},
+            Password => $self->{_proxy}{pass}
+        ) or die "Proxy connection error";
+        $aeh = AnyEvent::Handle->new( fh => $sock );
     }
     else {
         AE::log info => "not using proxy: %s:%d", map{ $self->{_dc}{$_}} qw/addr port/;
         $aeh = AnyEvent::Handle->new( 
             connect => [ map{ $self->{_dc}{$_}} qw/addr port/ ],
-            on_connect_error => sub { die "Connection error" },
-            on_connect => sub { $self->_mt($aeh) }
+            on_connect_error => sub { die "Connection error" }
         );
     }
-}
-
-sub _mt
-{    
-    my( $self, $aeh ) = @_;
-
+    
     $self->{_mt} = MTProto->new( socket => $aeh, session => $self->{session}{mtproto},
             on_error => $self->_get_err_cb, on_message => $self->_get_msg_cb,
             debug => $self->{debug}
@@ -199,6 +192,7 @@ sub invoke
     $self->{_req}{$req_id}{query} = $query;
     # store handler for this query result
     $self->{_req}{$req_id}{cb} = $res_cb if defined $res_cb;
+    &{$self->{after_invoke}}($req_id, $query, $res_cb) if defined $self->{after_invoke};
     return $req_id;
 }
 

--- a/cborlog.pl
+++ b/cborlog.pl
@@ -63,9 +63,7 @@ $AnyEvent::Log::LOG->log_to_path($opts->logfile) if $opts->{logfile}; # XXX path
           $AnyEvent::Log::CTX{ (caller)[0] } ||= AnyEvent::Log::_pkg_ctx +(caller)[0],
           $_[0],
           map { is_utf8($_) ? encode_utf8 $_ : $_ } (
-              ($opts->verbose
-                  ? (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1]
-                  : $_[1]),
+               (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1],
                (@_ > 2 ? @_[2..$#_] : ())
           );
     };
@@ -74,9 +72,7 @@ $AnyEvent::Log::LOG->log_to_path($opts->logfile) if $opts->{logfile}; # XXX path
           $AnyEvent::Log::CTX{ (caller)[0] } ||= AnyEvent::Log::_pkg_ctx +(caller)[0],
           $_[0],
           map { is_utf8($_) ? encode_utf8 $_ : $_ } (
-              ($opts->verbose
-                  ? (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1]
-                  : $_[1]),
+               (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1],
                (@_ > 2 ? @_[2..$#_] : ())
           );
     };
@@ -263,10 +259,14 @@ my $watch = AnyEvent->timer(
     },
 );
 
-#my $signal = AnyEvent->signal( signal => 'INT', cb => sub {
-#        AE::log note => "INT recvd";
-#        $cond->send;
-#    } );
+my $signal;
+if ($^O ne 'MSWin32') {
+    $signal = AnyEvent->signal( signal => 'INT', cb => sub {
+            AE::log note => "INT recvd";
+            $cond->send;
+        }
+    );
+}
 
 $cond->recv;
 


### PR DESCRIPTION
Also supported `CBOR::XS->new->pack_strings(1)` mode where records
are pushed to array first, on which XBOR::XS will pack repeated
strings transparently to user code; so you one modify saver or write
a simple repacker for existing files (see cborlog.pl):

```
    while (length $cbor_data) {
	($rec, $octets) = $cbor->decode_prefix ($cbor_data);
	substr($cbor_data, 0, $octets) = '';
	my $clone = dclone $rec;
	push @all, unlock_hashref_recurse($clone);
    }

    my $packed = $CBOR::XS::MAGIC . $cbor->encode(\@all);
```