### PR TITLE
Bug fixes, renames, more logging, utils for history

### DIFF
--- a/ClifTg.pm
+++ b/ClifTg.pm
@@ -137,18 +137,18 @@ sub init {
 
 sub command_map
 {
-    argobject   => 'Teleperl::Command::Argobject',
-    chats       => 'Teleperl::Command::Chats',
-    dialogs     => 'Teleperl::Command::Dialogs',
-    history     => 'Teleperl::Command::History',
-    invoke      => 'Teleperl::Command::Invoke',
-    media       => 'Teleperl::Command::Media',
-    message     => 'Teleperl::Command::Message',
-    'read'      => 'Teleperl::Command::Read',
-    sessions    => 'Teleperl::Command::Sessions',
-    set         => 'Teleperl::Command::Set',
-    updates     => 'Teleperl::Command::Updates',
-    users       => 'Teleperl::Command::Users',
+    argobject   => 'CliTg::Command::Argobject',
+    chats       => 'CliTg::Command::Chats',
+    dialogs     => 'CliTg::Command::Dialogs',
+    history     => 'CliTg::Command::History',
+    invoke      => 'CliTg::Command::Invoke',
+    media       => 'CliTg::Command::Media',
+    message     => 'CliTg::Command::Message',
+    'read'      => 'CliTg::Command::Read',
+    sessions    => 'CliTg::Command::Sessions',
+    set         => 'CliTg::Command::Set',
+    updates     => 'CliTg::Command::Updates',
+    users       => 'CliTg::Command::Users',
  
     # built-in commands:
     help    => 'CLI::Framework::Command::Help',
@@ -282,7 +282,7 @@ sub report_update
     }
 }
 
-package Teleperl::Command::Message;
+package CliTg::Command::Message;
 use base "CLI::Framework::Command";
 
 use Telegram::MessageEntity;
@@ -371,10 +371,10 @@ sub run
     );
 }
 
-package Teleperl::Command::Set;
+package CliTg::Command::Set;
 use base "CLI::Framework::Command::Meta";
 
-*option_spec = \&Teleperl::settable_opts;
+*option_spec = \&CliTg::settable_opts;
 
 sub run
 {
@@ -403,7 +403,7 @@ sub run
     return $ret || "no opts changed";
 }
 
-package Teleperl::Command::Dialogs;
+package CliTg::Command::Dialogs;
 use base "CLI::Framework::Command::Meta";
 
 use Data::Dumper;
@@ -521,7 +521,7 @@ sub run
     );
 }
 
-package Teleperl::Command::Media;
+package CliTg::Command::Media;
 use base "CLI::Framework::Command";
 
 use Telegram::Messages::SendMedia;
@@ -544,7 +544,7 @@ sub run
     );
 }
 
-package Teleperl::Command::Users;
+package CliTg::Command::Users;
 use base "CLI::Framework::Command";
 
 use Data::Dumper;
@@ -557,7 +557,7 @@ sub run
     return Dumper $tg->{session}{users};
 }
 
-package Teleperl::Command::Chats;
+package CliTg::Command::Chats;
 use base "CLI::Framework::Command";
 
 use Data::Dumper;
@@ -570,7 +570,7 @@ sub run
     return Dumper $tg->{session}{chats};
 }
 
-package Teleperl::Command::Updates;
+package CliTg::Command::Updates;
 use base "CLI::Framework::Command::Meta";
 
 use Telegram::Updates::GetState;
@@ -595,7 +595,7 @@ sub run
     #    ), sub {say Dumper @_});
 }
 
-package Teleperl::Command::History;
+package CliTg::Command::History;
 use base "CLI::Framework::Command::Meta";
 
 use Telegram::InputPeer;
@@ -686,12 +686,12 @@ sub run
             min_id	=> $opts->{min_id} // 0,
             hash => 0
         ), sub {
-            $self->handle_history($peer, $_[0], $opts) if $_[0]->isa('Telegram::Messages::MessagesABC');
+            $self->handle_history($peer, $_[0], 0, $opts) if $_[0]->isa('Telegram::Messages::MessagesABC');
 
         } );
 }
 
-package Teleperl::Command::Read;
+package CliTg::Command::Read;
 use base "CLI::Framework::Command::Meta";
 
 use Telegram::Messages::ReadHistory;
@@ -749,7 +749,7 @@ sub run
     }
 }
 
-package Teleperl::Command::Sessions;
+package CliTg::Command::Sessions;
 use base "CLI::Framework::Command::Meta";
 
 use Telegram::Account::GetAuthorizations;
@@ -764,7 +764,7 @@ sub run
     $tg->invoke( Telegram::Account::GetAuthorizations->new, sub { $self->get_app->render(Dumper @_) } );
 }
 
-package Teleperl::Command::Invoke;
+package CliTg::Command::Invoke;
 use base "CLI::Framework::Command::Meta";
 
 use Telegram::ObjTable;
@@ -895,7 +895,7 @@ sub run
     );
 }
 
-package Teleperl::Command::Argobject;
+package CliTg::Command::Argobject;
 use base "CLI::Framework::Command::Meta";
 
 sub usage_text {
@@ -957,8 +957,8 @@ sub notify_of_subcommand_dispatch {
     $self->cache->set('_argobjarr' => $argobj);
 }
 
-package Teleperl::Command::Argobject::Push;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::Push;
+use base "CliTg::Command::Argobject";
 
 use Telegram::ObjTable;
 use Data::Dumper;
@@ -1046,8 +1046,8 @@ sub run
     return $#$argo;
 }
 
-package Teleperl::Command::Argobject::InputPeer;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::InputPeer;
+use base "CliTg::Command::Argobject";
 
 use Telegram::InputPeer;
 
@@ -1097,8 +1097,8 @@ sub run
     return $#$argo;
 }
 
-package Teleperl::Command::Argobject::Delete;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::Delete;
+use base "CliTg::Command::Argobject";
 
 sub validate
 {
@@ -1126,8 +1126,8 @@ sub run {
     return "Deleted $ret";
 }
 
-package Teleperl::Command::Argobject::Dump;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::Dump;
+use base "CliTg::Command::Argobject";
 
 use Data::Dumper;
 
@@ -1138,8 +1138,8 @@ sub run {
     return Dumper $self->cache->get('_argobjarr');
 }
 
-package Teleperl::Command::Argobject::Pop;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::Pop;
+use base "CliTg::Command::Argobject";
 
 use Data::Dumper;
 
@@ -1151,8 +1151,8 @@ sub run {
     return Dumper(pop @$argo);
 }
 
-package Teleperl::Command::Argobject::Shift;
-use base "Teleperl::Command::Argobject";
+package CliTg::Command::Argobject::Shift;
+use base "CliTg::Command::Argobject";
 
 use Data::Dumper;
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ For GUI application (currently minimal almost unusable quick & dirty proof-of-wo
   * treectrl
   * tklib (ctext tooltip widget)
 
-Not required in minimal run (optional for extra features):
+Not required in minimal run (optional for extra features), but may be moved to core in future:
 - CBOR::XS
+- Data::DPath
 
 Not yet used but discussed:
 - Template::Toolkit

--- a/cborsee.pl
+++ b/cborsee.pl
@@ -1,0 +1,73 @@
+use Modern::Perl;
+
+use CBOR::XS;
+use Data::Dumper;
+use POSIX;
+use TL::Object;
+use Telegram::ObjTable;
+use MTProto::ObjTable;
+
+require $_ for map { $_->{file} } values %Telegram::ObjTable::tl_type;
+require $_ for map { $_->{file} } values %MTProto::ObjTable::tl_type;
+
+use Data::DPath 'dpathr';
+use Getopt::Long::Descriptive;
+
+sub option_spec {
+    [ 'filter|f=s'  => 'Data::DPath filter expression' ],
+}
+
+### initialization
+
+my ($opts, $usage);
+
+eval { ($opts, $usage) = describe_options( '%c %o ...', option_spec() ) };
+die "Invalid opts: $@\nUsage: $usage\n" if $@;
+
+die "Input filename(s) must be specified\n" unless @ARGV;
+
+FILE: {
+my $fname = shift;
+last unless $fname;
+
+open FH, "<", $fname
+    or die "can't open '$fname': $!";
+binmode FH;
+
+my $cbor_data;
+
+# slurp all file at once :)
+{
+    local $/ = undef;
+    $cbor_data = <FH>;
+    close FH;
+}
+
+my $cbor = CBOR::XS->new;
+
+my ($rec, $octets, $filter);
+
+local $Data::Dumper::Indent = 1;
+local $Data::Dumper::Varname = $opts->filter ? 'filter' : '';
+$| = 1;
+
+$Data::DPath::USE_SAFE = 0; # or it will not see our classes O_o
+$filter = dpathr($opts->filter) if $opts->filter;
+
+sub one_rec {
+    say POSIX::strftime("%Y.%m.%d %H:%M:%S ", localtime delete $_[0]->{time})
+      . Dumper(defined $filter
+          ? $filter->match($_[0])
+          : $_[0]
+      );
+}
+
+while (length $cbor_data) {
+    ($rec, $octets) = $cbor->decode_prefix ($cbor_data);
+#    print " octets=$octets ";
+    substr($cbor_data, 0, $octets) = '';
+    one_rec $_ for (ref $rec eq 'HASH' ? $rec : @$rec);
+}
+
+redo;
+}


### PR DESCRIPTION
* finish rename of Teleperl package to CliTg (now ready for __true__ Teleperl)
* fix bug in RpcError which could came inside RpcResult (fucking protocol!)
* minor history bug fixes
* add small utilities to dump one chat to CBOR and to see CBOR contents:
  - it allows to supply Data::DPath filter expression, e.g.

  `cborsee.pl -f "//.[isa('Telegram::FileLocation')]" 2019.06.01_*.cbor`

  to see just file objects inside large object trees.