### PR TITLE
CLI: describe/inputuser/menu; TG: noupdates, generator, etc.

### DIFF
--- a/CLI/Framework/Application.pm
+++ b/CLI/Framework/Application.pm
@@ -986,6 +986,8 @@ sub _cmd_request_completions {
             }
 #print "aft=".join(':',@prefixARGV)."|ARGV=".join(':',@ARGV)."\n";
             # now $cmd is last subcmd, @prefixARGV is it's args
+            # FIXME TODO consumed opts parts missing from @prefixARGV and thus
+            # from $lastopt XXX check if fixing won't break existing code
 
             # provide data for cmd helper methods from init()
             $cmd->set_cache( $app->cache );

--- a/CLI/Framework/Command/Menu.pm
+++ b/CLI/Framework/Command/Menu.pm
@@ -15,7 +15,7 @@ sub usage_text {
 }
 
 sub run {
-    my ($self, $opts, @args) = @_;
+    my ($self, @args) = @_;
 
     return $self->menu_txt(@args);
 }

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -192,6 +192,9 @@ sub invoke
         $query = Telegram::InvokeWithLayer->new( layer => 91, query => $conn ); 
         $self->{_first} = 0;
     }
+    elsif ($self->{noupdate}) {
+        $query = Telegram::InvokeWithoutUpdates->new( query => $query );
+    }
     if ($self->{_lock}) {
         $self->_enqueue( $query, $res_cb );
     }

--- a/cborsee.pl
+++ b/cborsee.pl
@@ -60,7 +60,7 @@ my $tl_len = 0;
 sub one_rec {
     my $obj = exists $_->{in} ? $_->{in} : $_->{out};
     $obj = $_->{data} unless $obj;
-    $tl_len += 4*scalar($obj->pack);
+    $tl_len += 4*scalar($obj->pack) if $obj;
     say POSIX::strftime("%Y.%m.%d %H:%M:%S ", localtime delete $_[0]->{time})
       . Dumper(defined $filter
           ? $filter->match($_[0])

--- a/tl-gen.pl
+++ b/tl-gen.pl
@@ -47,6 +47,7 @@ $parser->YYData->{types} = [];
 $parser->YYData->{funcs} = [];
 
 my $prefix = shift @ARGV;
+my $srcfile = $ARGV[0];
 
 my $input;
 {
@@ -130,7 +131,7 @@ for my $type (@types) {
 
     unless ($type->{func}) {
         unless (exists $typeset{$basepkg}) {
-            print $f "package $basepkg;\n1;\n\n";
+            print $f "package $basepkg;\nour \$VERSION='$srcfile';\n\n";
             $typeset{$basepkg} = undef;
         }
     }
@@ -159,12 +160,16 @@ for my $type (@types) {
         printf $f "  %-17s => { type => ", $arg->{name};
         if (exists $builtin{$arg->{type}{name}}) {
             print $f "'" . $arg->{type}{name} . "', builtin => 1, ";
+        } elsif ($arg->{type}{bang}) {
+            print $f "'" . $arg->{type}{name} . "', ";
         } else {
-            my ($basepath, $basepkg) = pkgname($prefix, $arg->{type}{name});
+            my (undef, $basepkg) = pkgname($prefix, $arg->{type}{name});
             print $f "'$basepkg', ";
         }
         print $f "vector => 1, " if exists $arg->{type}{vector};
-        print $f "optional => '$arg->{cond}{name}', " if $arg->{cond};
+        print $f "bang => 1, " if exists $arg->{type}{bang};
+        print $f "optional => '$arg->{cond}{name}.".int(log( $arg->{cond}{bitmask})/log(2))."', "
+            if $arg->{cond};
         print $f "},\n";
     }
     print $f ");\n";
@@ -276,7 +281,7 @@ for my $type (@types) {
 
 open my $f, ">$prefix/ObjTable.pm" or die "$!";
 
-print $f "package ".$prefix."::ObjTable;\nour \$GENERATED_FROM='$ARGV[0]';\nour %tl_type = (\n";
+print $f "package ".$prefix."::ObjTable;\nour \$GENERATED_FROM='$srcfile';\nour %tl_type = (\n";
 for my $type (@types) {
     my ($path, $pkg) = pkgname($prefix, $type->{id});
     my ($basepath, $basepkg) = pkgname($prefix, $type->{type}{name});


### PR DESCRIPTION
* Make menu in CLI less annoying (and fix bug in CLIF)
* Fix `describe` command in CLI to be actually working
* Add `argobject inputuser` subcommand
* Save more information in schema generator, by adding $VERSION to
  every Abstract Base Class - this serves dual purpose, both as file
  version marker (due to recent server bugs, you may have to deal with
  different generated files, little more convenience) and to ease
  runtime class introspection by variable presence.
* Take above into account in CBOR logsaver/dumper
* Add `InvokeWithoutUpdates` wrapper to Telegram.pm in `noupdates` mode...
* ...and use non-update-triggering first request in example history dumper.