### PR TITLE
Refactor a little & make GUI chewing layer 91

### DIFF
--- a/Teleperl/Util.pm
+++ b/Teleperl/Util.pm
@@ -1,0 +1,112 @@
+package Teleperl::Util;
+
+use Modern::Perl;
+use base 'Exporter';
+
+use Carp;
+use Encode ':all';
+use POSIX;
+use Scalar::Util qw(reftype);
+use AnyEvent::Log;
+
+our $VERSION     = 0.01;
+our @EXPORT      = qw(install_AE_log_crutch install_AE_log_SIG_WARN install_AE_log_SIG_DIE);
+our @EXPORT_OK   = qw(get_AE_log_format_cb unlock_hashref_recurse);
+
+=pod
+
+Plain old module with misc utilities
+
+=cut
+
+# XXX workaround crutch of AE::log not handling utf8 & function name
+sub install_AE_log_crutch
+{
+    no strict 'refs';
+    no warnings 'redefine';
+    *AnyEvent::log    = *AE::log    = sub ($$;@) {
+        AnyEvent::Log::_log
+          $AnyEvent::Log::CTX{ (caller)[0] } ||= AnyEvent::Log::_pkg_ctx +(caller)[0],
+          $_[0],
+          map { is_utf8($_) ? encode_utf8 $_ : $_ } ( # TODO fix uninit from top level
+               (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1],
+               (@_ > 2 ? @_[2..$#_] : ())
+          );
+    };
+    *AnyEvent::logger = *AE::logger = sub ($;$) {
+        AnyEvent::Log::_logger
+          $AnyEvent::Log::CTX{ (caller)[0] } ||= AnyEvent::Log::_pkg_ctx +(caller)[0],
+          $_[0],
+          map { is_utf8($_) ? encode_utf8 $_ : $_ } (
+               (split(/::/, (caller(1))[3]))[-1] . ':' . (caller(0))[2] . ": " . $_[1],
+               (@_ > 2 ? @_[2..$#_] : ())
+          );
+    };
+}
+
+# catch all non-our Perl's warns to log with stack trace
+# we can't just Carp::Always or Devel::Confess due to AnyEvent::Log 'warn' :(
+sub install_AE_log_SIG_WARN {
+    $SIG{__WARN__} = sub {
+        scalar( grep /AnyEvent|\blog/, map { (caller($_))[0..3] } (1..3) )
+            ? warn $_[0]
+            : AE::log warn => &Carp::longmess;
+    };
+}
+
+sub install_AE_log_SIG_DIE {
+    $SIG{__DIE__} = sub {
+        my $mess = &Carp::longmess;
+        $mess =~ s/( at .*?\n)\1/$1/s;    # Suppress duplicate tracebacks
+        AE::log alert => $mess;
+        die $mess;
+    };
+}
+
+sub get_AE_log_format_cb {
+    return sub {
+        my ($time, $ctx, $lvl, $msg) = @_;
+
+        my $ts = POSIX::strftime("%H:%M:%S", localtime $time)
+               . sprintf ".%04d", 1e4 * ($time - int($time));
+
+        # XXX we need just timestamp! but AE has no cb for just time..
+        # XXX so copypaste rest from AnyEvent::Log
+        my $ct = " ";
+        my @res;
+
+        for (split /\n/, sprintf "%-5s %s: %s", $AnyEvent::Log::LEVEL2STR[$_[2]], $_[1][0], $_[3]) {
+            push @res, "$ts$ct$_\n";
+            $ct = " + ";
+        }
+
+        join "", @res
+    };
+}
+
+# adapted from Hash::Util to process arrays
+sub unlock_hashref_recurse {
+    my $hash = shift;
+
+    my $htype = reftype $hash;
+    return unless defined $htype;
+    if ($htype eq 'ARRAY') {
+        foreach my $el (@$hash) {
+            unlock_hashref_recurse($el)
+                if defined reftype $el;
+        }
+        return;
+    }
+
+    foreach my $value (values %$hash) {
+        my $type = reftype($value);
+        if (defined($type) and ($type eq 'HASH' or $type eq 'ARRAY')) {
+            unlock_hashref_recurse($value);
+        }
+        Internals::SvREADONLY($value,0);
+    }
+    Hash::Util::unlock_ref_keys($hash);
+    return $hash;
+}
+
+1;

--- a/cborpack.pl
+++ b/cborpack.pl
@@ -1,0 +1,131 @@
+use Modern::Perl;
+
+use CBOR::XS;
+use Data::Dumper;
+use Teleperl::Util qw(unlock_hashref_recurse);
+use Telegram::ObjTable;
+use MTProto::ObjTable;
+use File::Find;
+use Storable qw(dclone);
+use Getopt::Long::Descriptive;
+
+require $_ for map { $_->{file} } values %Telegram::ObjTable::tl_type;
+require $_ for map { $_->{file} } values %MTProto::ObjTable::tl_type;
+
+sub option_spec {
+    [ 'daily=s'     => 'regexp, $1_$2.cbor to $1.cbor, e.g. 24 hour files to one per-day' ],
+    [ 'mtime=i'     => 'analogous to find -mtime, for use with --daily' ],
+    [ 'prefix|p=s'  => 'prefix path for output files' ],
+    [ 'dry|n'       => 'do no action, just print file names' ],
+    [ 'verbose|v:+' => 'more twitting about actions', { default => 0} ],
+}
+
+### initialization
+
+my ($opts, $usage);
+
+eval { ($opts, $usage) = describe_options( '%c %o ...', option_spec() ) };
+die "Invalid opts: $@\nUsage: $usage\n" if $@;
+
+### pack sub
+
+my $cbor_data;
+
+my $cbor  = CBOR::XS->new;
+my $cborp = CBOR::XS->new->pack_strings(1);
+
+my ($rec, $octets, @all);
+
+sub output_file {
+    my $outfname = shift;
+    say "starting output file $outfname";
+    while (my $infname = shift) {
+        say "\tinput file $infname" if $opts->verbose;
+        next if $opts->dry;
+        my $mtime = (stat($infname))[9];
+        push @all, { infname => $infname, mtime => $mtime };
+        open FH, "<", $infname
+            or die "can't open '$infname': $!";
+
+        binmode FH;
+
+        # slurp all file at once :)
+        {
+            local $/ = undef;
+            $cbor_data = <FH>;
+            close FH;
+        }
+
+        while (my $left = length $cbor_data) {
+            last if $left == 3 and $cbor_data eq $CBOR::XS::MAGIC;
+            ($rec, $octets) = $cbor->decode_prefix ($cbor_data);
+            substr($cbor_data, 0, $octets) = '';
+            my $one_rec = sub {
+                my $rec = shift;
+                my $clone = dclone $rec;
+                if (exists $clone->{schema}) {
+                    $clone->{marktime} = delete $clone->{time};
+                }
+                push @all, unlock_hashref_recurse($clone);
+            };
+            $one_rec->($_) for (ref $rec eq 'HASH' ? $rec : @$rec);
+
+        }
+    }
+    return if $opts->dry;
+
+    my $packed = $CBOR::XS::MAGIC 
+               . $cborp->encode({    # what version decoder should use
+                       packtime => time,
+                       schema => $Telegram::ObjTable::GENERATED_FROM,
+                   })
+               . $cborp->encode(\@all);
+
+    open OUT, ">", $outfname
+        or die "can't open '$outfname': $!";
+
+    binmode OUT;
+    $\ = undef;
+
+    print OUT $packed;
+
+    close OUT;
+    @all = ();
+}
+
+## main work
+$opts->{verbose}++ if $opts->dry;
+$opts->{prefix} = "." unless $opts->prefix;
+$opts->{prefix} .= "/" unless $opts->{prefix} =~ /\/$/;
+
+if (my $pat = $opts->daily) {
+    die "need directory arg" unless -d $ARGV[0];
+    my %list;
+    my $mtime = $opts->mtime || 0;
+    my ($dev, $ino, $mode, $nlink, $uid, $gid, $rdev);
+    say "daily: start searching" if $opts->verbose;
+    find(sub {
+            my $match = 0;
+            say "find wanted on $_" if $opts->verbose > 1;
+            /$pat/s &&
+            (($dev, $ino, $mode, $nlink, $uid, $gid, $rdev) = lstat($_)) &&
+            ($match = 1);
+            if ($mtime) {
+                $match = 0 unless int(-M _) > $mtime;
+            }
+            return unless $match;
+            # final action
+            $list{"$1.cbor"} = [] unless exists $list{"$1.cbor"};
+            push @{ $list{"$1.cbor"} }, $File::Find::name ; 
+        },
+        $ARGV[0],
+    );
+    say "file list built, beginning to pack" if $opts->verbose or $opts->dry;
+    output_file($opts->{prefix}.$_, sort @{ $list{$_} }) for sort keys %list;
+}
+else {
+    my $fname = "$ARGV[0]";
+    $fname =~ s/cbor$/packcbor/
+        or $fname = "$ARGV[0].pack";
+    output_file($fname, $ARGV[0]);
+}

--- a/cborsee.pl
+++ b/cborsee.pl
@@ -15,6 +15,9 @@ use Getopt::Long::Descriptive;
 
 sub option_spec {
     [ 'filter|f=s'  => 'Data::DPath filter expression' ],
+    [ 'tl_len=s'    => 'try to pack back to TL and count length' ],
+    [ 'verbose|v:+' => 'more twitting about actions', { default => 0} ],
+    [ 'nomark'      => 'do not output marker records', { default => 0} ],
 }
 
 ### initialization
@@ -60,7 +63,16 @@ my $tl_len = 0;
 sub one_rec {
     my $obj = exists $_->{in} ? $_->{in} : $_->{out};
     $obj = $_->{data} unless $obj;
-    $tl_len += 4*scalar($obj->pack) if $obj;
+    if ($opts->tl_len) {
+        eval { $tl_len += 4*scalar($obj->pack) if $obj };
+        warn "inaccurate tl_len $@" if $@;
+    }
+    unless (exists $_[0]->{time}) {
+        local $Data::Dumper::Indent = 0;
+        local $Data::Dumper::Varname = "markerecrd";
+        say Dumper $_[0] unless $opts->{nomark};
+        return;
+    }
     say POSIX::strftime("%Y.%m.%d %H:%M:%S ", localtime delete $_[0]->{time})
       . Dumper(defined $filter
           ? $filter->match($_[0])
@@ -68,14 +80,20 @@ sub one_rec {
       );
 }
 
-while (length $cbor_data) {
+while (my $left = length $cbor_data) {
+    if ($opts->verbose) {
+        my $ofs = $cborlen-length($cbor_data);
+        say sprintf "decoding at offset 0x%x, %d bytes left", $ofs, $left;
+    }
+    # log saver was buggy one time
+    last if $left == 3 and $cbor_data eq $CBOR::XS::MAGIC;
     ($rec, $octets) = $cbor->decode_prefix ($cbor_data);
 #    print " octets=$octets ";
     substr($cbor_data, 0, $octets) = '';
     one_rec $_ for (ref $rec eq 'HASH' ? $rec : @$rec);
 }
 
-say "cborlen=$cborlen tl_len=$tl_len";
+say "cborlen=$cborlen tl_len=$tl_len" if $opts->tl_len;
 
 redo;
 }


### PR DESCRIPTION
Refactor common crutches of AnyEvent magic from repeating in every prog
to new common plain (non-OO) module Teleperl::Util, being fixable in
central place now.

Refactor GUI a little in preparation for several message text widgets.

Based on previous schema meta-info in class generator,
Implement partial support for Instant View 2.0 in GUI,
so it does not crash on layer 91 now, and understands older lists also
(though visual indentation for nested lists is still to be done).