### PR TITLE
A lot of changes and fixes since Sep 22: review 'new-teleperl'

### DIFF
--- a/Telegram.pm
+++ b/Telegram.pm
@@ -9,6 +9,7 @@ package Telegram;
 =cut
 
 use Modern::Perl;
+use Data::DPath 'dpath';
 use Data::Dumper;
 use Carp;
 
@@ -43,20 +44,22 @@ use Telegram::Messages::SendMessage;
 use Telegram::InputPeer;
 
 use base 'Class::Stateful';
-use fields qw(
+use fields qw( _filters
     _mt _dc _app _proxy _timer _first _req _lock _flood_timer _queue _upd 
-    reconnect session auth keepalive noupdate force_new_session
+    reconnect session tempkey authdc keepalive noupdate force_new_session
 );
 
 # args: DC, proxy and stuff
 sub new
 {
-    my @args = qw( noupdate keepalive reconnect force_new_session session auth );
+    my @args = qw( noupdate keepalive reconnect force_new_session session authdc tempkey );
     my ($class, %arg) = @_;
     my $self = fields::new( ref $class || $class );
     $self->SUPER::new( 
         init => undef,
         connecting => undef,
+        sendtempkey => undef,
+        waittempkey => undef,
         connected => [ 
             sub { 
                 $self->_dequeue;
@@ -78,6 +81,7 @@ sub new
 
     @$self{@args} = @arg{@args};
 
+    $self->{_filters} = { raw => [ { name => 'msg', filter => dpath('/') } ] };
     $self->{_first} = 1;
     $self->{_lock} = 1;
 
@@ -127,48 +131,94 @@ sub _mt
     my $mt = MTProto->new( 
             socket => $aeh, 
             session => ( $force_new ? {} : $self->{session} ),
-            keys => $self->{auth}, 
+            dcinstance => $self->{authdc}, 
     );
     $self->{_mt} = $mt;
     
     $mt->reg_cb( state => sub { 
             shift; AE::log debug => "MTP state @_";
             if ($_[0] eq 'session_ok') {
-                $self->_state('connected');
+                $self->_state($self->{tempkey} ? 'sendtempkey' : 'connected');
             }
     } );
     $mt->reg_cb( fatal => sub { shift; AE::log warn => "MTP fatal @_" } );
     $mt->reg_cb( message => sub { shift; $self->_msg_cb(@_) } );
     $mt->reg_cb( error => sub { shift; $self->_error_cb(@_) } );
 
-    $mt->start_session;
+    $mt->reg_cb( bad_salt => sub {
+            shift;
+            AE::log debug => "requesting future salts";
+            $self->{_mt}->invoke( [
+                    MTProto::GetFutureSalts->new( num => 9 ),
+                    # fire and forget, errors here are uncritical
+            ] );
+            $self->register_filter_event('raw',
+                future_salts => "//.[isa('MTProto::FutureSalts')]"
+            );
+    } );
 
+    $self->reg_cb( raw_future_salts => sub {
+            shift;
+            AE::log debug => "got future salts event";
+            $self->{authdc}{future_salts} = $_[0];
+    } );
+
+    $mt->start_session;
 }
 
 sub _real_invoke
 {
-    my ( $self, $query, $cb ) = @_;
+    my ( $self, $query, $cb, %param ) = @_;
     $self->{_mt}->invoke( [ $query, 
         sub {
-            my $req_id = shift;
-            $self->{_req}{$req_id}{query} = $query;
-            $self->{_req}{$req_id}{cb} = $cb if defined $cb;
-            AE::log debug => "invoked $req_id for " . ref $query;
-            $self->event('after_invoke', $req_id, $query, $cb);
+            my ($req_id, $when) = @_;
+            AE::log debug => "invoke ($when) $req_id for " . ref $query;
+            my $id_cb = delete $param{on_send};
+            my $ack_cb = delete $param{on_ack};
+            if ($when eq 'push') {
+                $self->{_req}{$req_id}{$_} = $param{$_} for keys %param;
+                $self->{_req}{$req_id}{query} = $query;
+                $self->{_req}{$req_id}{cb} = $cb if defined $cb;
+                $self->event('raw_after_invoke', $req_id, $query, $cb, $id_cb, %param);
+                $id_cb->($req_id) if defined $id_cb;
+            }
+            elsif ($when eq 'ack') {
+                $self->event('raw_after_ack', $req_id, $query, $cb, $ack_cb);
+                $ack_cb->($req_id) if defined $ack_cb;
+            }
         } 
     ] );
 }
 
-## layer wrapper
+## layer and other cranks wrapper
 
 sub invoke
 {
-    my ($self, $query, $res_cb, $service) = @_;
+    my ($self, $query, $res_cb, %param) = @_;
     my $req_id;
 
-    Carp::confess unless defined $query;
-    AE::log info => "invoke: " . ref $query;
-    AE::log trace => Dumper $query;
+    {   # argument check
+        Carp::confess "empty query" unless defined $query;
+        my $class = ref $query;
+        my $tl_type = (grep {
+            exists $_->{func} and $_->{class} eq $class
+            } (values %Telegram::ObjTable::tl_type, values %MTProto::ObjTable::tl_type) # XXX disallow MTProto?
+        )[0];
+        Carp::confess "query of type $class is not amongst compiled schema functions"
+            unless defined $tl_type;
+        if ($query->isa('Telegram::Auth::BindTempAuthKey') or exists $tl_type->{bang}) {
+            AE::log error => "%s TL API function can't be freely invoked by user, fix %s", $class, Carp::longmess;
+            return;
+        }
+        AE::log info => "invoke: " . $class;
+        AE::log trace => Dumper $query;
+    }
+
+    # docs says:
+    # The helper method invokeWithLayer can be used only together with initConnection
+    # ....
+    # initConnection must also be called after each auth.bindTempAuthKey
+    # thus the latter is handled as sepaarte state, even before _first
     if ($self->{_first}) {
         AE::log debug => "first, using wrapper";
         my $inner = $query;
@@ -182,34 +232,53 @@ sub invoke
                 system_lang_code => 'en',
                 lang_pack => '',
                 lang_code => 'en',
-                query => $inner
+                query => $inner,
+                # TODO report proxy somewhere in future after MTProxy support...
         );
         $query = Telegram::InvokeWithLayer->new( layer => 91, query => $conn ); 
         $self->{_first} = 0;
     }
-    elsif ( $self->{noupdate} ) {
+    elsif ( $self->{noupdate} || $param{noupdate} ) {
         $query = Telegram::InvokeWithoutUpdates->new( query => $query );
     }
-    if ($self->{_lock} and not $service) {
-        $self->_enqueue( $query, $res_cb );
+
+    # GDPR export
+    if (my $range = delete $param{with_range}) {
+        $query = Telegram::InvokeWithMessagesRange->new( range => $range, query => $query );
+    }
+    if (my $takid = delete $param{with_takeout}) {
+        $query = Telegram::InvokeWithTakeout->new( takeout_id => $takid, query => $query );
+    }
+    # XXX TODO what is the order of invokeWithTakeout / invokeWithMessagesRange
+    # relative to AfterMsg(s) and each other? is it right?
+    if (my $msg_id = delete $param{after_msg}) {
+        $query = Telegram::InvokeAfterMsg->new( msg_id => $msg_id, query => $query );
+    }
+    elsif (my $msg_ids = delete $param{after_msgs}) {
+        $query = Telegram::InvokeAfterMsgs->new( msg_ids => $msg_ids, query => $query );
+    }
+
+    # finally query is wrapped as needed
+    if ($self->{_lock} and not $param{noqueue}) {
+        $self->_enqueue( $query, $res_cb, %param );
     }
     else {
-        $self->_real_invoke( $query, $res_cb );
+        $self->_real_invoke( $query, $res_cb, %param );
     }
 }
 
 sub _enqueue
 {
-    my ($self, $query, $cb) = @_;
+    my $self = shift;
     AE::log debug => "session locked, enqueue";
-    push @{$self->{_queue}}, [$query, $cb];
+    push @{$self->{_queue}}, [@_];
 }
 
 sub _dequeue
 {
     my $self = shift;
     local $_;
-    $self->_real_invoke($_->[0], $_->[1]) while ( $_ = shift @{$self->{_queue}} );
+    $self->_real_invoke(@$_) while ( $_ = shift @{$self->{_queue}} );
     $self->{_lock} = 0;
 }
 
@@ -218,6 +287,14 @@ sub flush
     my $self = shift;
     $self->{_queue} = [];
     $self->_state('connected');
+}
+
+sub cancel
+{
+    my ($self, $req_id) = @_;
+    AE::log debug => "Cancelling request $req_id";
+    delete $self->{_req}{$req_id};
+    $self->{_mt}->rpc_drop_answer($req_id);
 }
 
 sub _handle_rpc_result
@@ -318,6 +395,8 @@ sub _msg_cb
     AE::log info => "%s %s", ref $msg, (exists $msg->{object} ? ref($msg->{object}) : '');
     AE::log trace => Dumper $msg->{object};
 
+    $self->_run_filters(raw => $msg);
+
     # RpcResults
     $self->_handle_rpc_result( $msg->{object} )
         if ( $msg->{object}->isa('MTProto::RpcResult') );
@@ -346,6 +425,31 @@ sub _get_timer_cb
         $self->{_mt}->invoke( [ MTProto::Ping->new( ping_id => rand(2**31) ) ] ) 
             if $self->{keepalive};
     }
+}
+
+## process filters from specified table and emit events
+sub _run_filters
+{
+    my ($self, $table, $data) = @_;
+
+    for my $rule ($self->{_filters}{$table}) {
+        if (my @res = $rule->{filter}->match($data)) {
+            $self->event( $table . '_' . $rule->{name}, @res );
+        }
+    }
+}
+
+## allow user add new filters to table
+sub register_filter_event {
+    my ($self, $table, $evname, $expression) = @_;
+
+    # XXX TODO support more tables?
+    die "unsupported filter table" unless $table eq 'raw';
+
+    push @{ $self->{_filters}{$table} }, +{
+            name    => $evname,
+            filter  => dpath($expression),
+        };
 }
 
 1;

--- a/Teleperl.pm
+++ b/Teleperl.pm
@@ -18,6 +18,7 @@ use Teleperl::Storage;
 use base 'Class::Event';
 
 use AnyEvent;
+use Data::DPath 'dpath';
 use Data::Dumper;
 
 use Telegram::Help::GetConfig;
@@ -39,6 +40,8 @@ use Telegram::Peer;
 use Telegram::InputFileLocation;
 use Telegram::Upload::GetFile;
 
+use constant ROTTEN_SESSION_TIMEOUT => 864000;  # TODO dynamically by future_salts
+
 sub new
 {
     my ($self, %arg) = @_;
@@ -55,13 +58,21 @@ sub new
     my $storage = $arg{storage};
     $self->{_storage} = $storage;
 
-    $self->{_config} = $storage->config;
+    $self->{_config} = $storage->get(session => '/config');
+    $self->{home_dc} = $storage->get(session => '/home_dc');
 
-    $self->{_upd} = Teleperl::UpdateManager->new( $new_session ? {} : $storage->upd_state );
-    $self->{_cache} = Teleperl::PeerCache->new( session => $storage->peer_cache );
+    $self->{_upd} = Teleperl::UpdateManager->new( $new_session ? {} : $storage->get('update_state') );
+    $self->{_cache} = Teleperl::PeerCache->new( session => $storage->get('cache') );
     $self->{_storage} = $storage;
 
-    $self->{_tg} = $self->_spawn_tg( $self->{_config}{home_dc} // 0, 1 );
+    # purge senile sessions
+    my $sesspace = $storage->get('session');
+    for my $dc (keys %{ $sesspace->{sessions} }) {
+        my $sdc = $sesspace->{sessions}->{$dc};
+        $sdc = [ grep { ($_->{time}//0) > time() - ROTTEN_SESSION_TIMEOUT } @$sdc ];
+    }
+
+    $self->{_tg} = $self->_spawn_tg( $self->{home_dc} // 0, 1 );
     
     $self->{_upd}->reg_cb( query => sub { shift; $self->invoke(@_) } );
     $self->{_upd}->reg_cb( cache => sub { shift; $self->{_cache}->cache(@_) } );
@@ -75,6 +86,26 @@ sub new
 
     $self->{_file_part_size} = 2 ** 19;
     $self->{autofetch} = $arg{autofetch} // 0;
+    $self->{noupdate} = $arg{noupdate} // 0;
+
+    # example of filters XXX TODO should think of chaining filters e.g. to capture page id
+    if ($self->{autofetch} > 1) {
+        $self->register_filter_event('update',
+            webpage_photo   => "//.[isa('Telegram::WebPage')]//.[isa('Telegram::Photo')]"
+        );
+        $self->register_filter_event('update',
+            webpage_document=> "//.[isa('Telegram::WebPage')]//.[isa('Telegram::Document')]"
+        );
+        $self->reg_cb( update_webpage_photo => sub {
+            shift;
+            $self->_handle_photo( webpage => 1, @_ );
+        } );
+        $self->reg_cb( update_webpage_document => sub {
+            shift;
+            $self->_handle_document( webpage => 1, @_ );
+        } );
+    }
+
     return $self;
 }
 
@@ -91,14 +122,17 @@ sub start
                     my $config = shift;
                     if ( $config->isa('Telegram::Config') ) {
                         # assume this is home dc
-                        $self->{_config}{home_dc} = $config->{this_dc}
-                            unless defined $self->{_config}{home_dc};
-                        # save auth
-                        unless ( $self->{_storage}->mt_auth->{$config->{this_dc}} ) {
-                            $self->{_storage}->mt_auth->{$config->{this_dc}} = 
-                                $self->{_tg}{auth};
+                        unless (defined $self->{home_dc}) {
+                            $self->{home_dc} = $config->{this_dc};
+                            # save session
+                            $self->{_storage}->get("session")->{home_dc} = $self->{home_dc};
                         }
-                        $self->{_config}{config} = $config 
+                        # save auth
+                        my $authdc = $self->{_storage}->get(auth => "/dc/$config->{this_dc}");
+                        unless ( $authdc ) {
+                            $authdc = $self->{_tg}{authdc};
+                        }
+                        $self->{_config} = $config;
                     }
                 }
             );
@@ -112,10 +146,10 @@ sub _spawn_tg
 
     AE::log debug => "spawn new Telegram for DC#$dc%s", $main ? " as main" : "";
 
-    my %param = $self->{_storage}->tg_param;
+    my %param = %{ $self->{_storage}->get('config') };
 
     if ($dc) {
-        my @options = grep { $_->{id} == $dc } @{$self->{_config}{config}{dc_options}};
+        my @options = grep { $_->{id} == $dc } @{$self->{_config}{dc_options}};
 
         if (defined $param{proxy}) {
             @options = grep { defined $_->{static} } @options;
@@ -129,20 +163,34 @@ sub _spawn_tg
         $param{dc}{port} = $options[0]{port};
     }
 
-    my $dc_auth = $dc ? $self->{_storage}->mt_auth->{$dc} : {};
+    my $dc_auth = $dc ? $self->{_storage}->get(auth => "/dc/$dc") : {};
     unless (defined $dc_auth) {
-        $self->{_storage}->mt_auth->{$dc} = $dc_auth = {};
+        my $adc = $self->{_storage}->get(auth => "/dc");
+        $adc->{$dc} = $dc_auth = {};
     }
+    my $main_sid = $self->{_storage}->get(session => '/main_session_id');
+    my $dc_sessi = $self->{_storage}->get(session => "/sessions/$dc");
+    my $session = (grep { $main ? ($_->{id} eq $main_sid) : 1 } @$dc_sessi)[0];
+    $session = {} unless $session;
+    # TODO full-fledged session manager instead of one (first) per-dc session
+
     my $tg = Telegram->new( %param,
         force_new_session => $self->{_force_new_session},
         keepalive => 1,
-        auth => $dc_auth,
-        session => ($main and $dc) ? $self->{_storage}->mt_session : {}
+        authdc => $dc_auth,
+        session => $session,
+        noupdate => (!$main or $self->{noupdate}),
     );
     
     if ($main) {
         $tg->reg_cb( new_session => sub { $self->{_upd}->sync } );
         $tg->reg_cb( connected => sub {
+                my $sesspace =  $self->{_storage}->get('session');
+                if (not defined $sesspace->{main_session_id}) {
+                    $sesspace->{main_session_id} = $session->{id};
+                    push @$dc_sessi, $session
+                        unless grep { $_->{id} eq $session->{id} } @$dc_sessi;
+                }
                 AE::log info => "connected";
                 $self->{_upd}->sync
         });
@@ -157,6 +205,9 @@ sub _spawn_tg
 
         $tg->reg_cb( migrate => sub { shift; $self->_migrate(@_) } );
     }
+    else {
+        push @$dc_sessi, $session unless defined $session->{id};
+    }
     return $tg;
 }
 
@@ -166,21 +217,52 @@ sub _migrate
 
     undef $self->{_tg};
 
-    unless ( defined $self->{_config}{config} ) {
+    unless ( defined $self->{_config} ) {
         AE::log error => "forced to migrate to $dc, but no config";
         $self->event( error => { error_message => "Nowhere to migrate" } );
         return;
     }
-    $self->{_config}{home_dc} = $dc;
+    $self->{home_dc} = $dc;
+    $self->{_storage}->get("session")->{home_dc} = $self->{home_dc};
     $self->{_tg} = $self->_spawn_tg( $dc, 1 );
     $self->{_tg}->start;
     $self->{_tg}->invoke( $req->{query}, $req->{cb} );
+}
+
+## process filters from specified table and emit events
+sub _run_filters
+{
+    my ($self, $table, $data) = @_;
+
+    for my $rule ($self->{_filters}{$table}) {
+        if (my @res = $rule->{filter}->match($data)) {
+            $self->event( $table . '_' . $rule->{name}, @res );
+        }
+    }
+}
+
+## allow user add new filters to table
+sub register_filter_event {
+    my ($self, $table, $evname, $expression) = @_;
+
+    # XXX TODO support more tables?
+    die "unsupported filter table"
+        unless grep { $table eq $_ } ('raw', 'update');
+
+    push @{ $self->{_filters}{$table} }, +{
+            name    => $evname,
+            filter  => dpath($expression),
+        };
 }
 
 sub _handle_update
 {
     my ($self, $update) = @_;
 
+    # fix this shit to always be uniform full Telegram::Message before
+    # handling, if it is not yet XXX TODO wtf UpdateShortSentMessage ?! docs:
+    # 'chat has to be EXTRACTED FROM THE METHOD CALL THAT RETURNED THIS OBJECT'
+    # so not here?.. >_<
     if ( $update->isa('Telegram::UpdateNewMessage') or
          $update->isa('Telegram::UpdateNewChannelMessage')
     ) {
@@ -219,6 +301,7 @@ sub _handle_update
 
     AE::log trace => "update: ". Dumper($update);
 
+    $self->_run_filters(update => $update);
 }
 
 sub _handle_message
@@ -230,45 +313,59 @@ sub _handle_message
     if ( $self->{autofetch} and defined $mesg->{media} ) {
         if ( $mesg->{media}->isa('Telegram::MessageMediaDocument') ) {
             my $doc = $mesg->{media}{document};
-            my $filename = $self->{_storage}{files};
-            $filename .= $doc->{dc_id} .'_'. $doc->{id};
-
-            $self->fetch_file(
-                dst => $filename,
-                type => 'doc',
-                dc => $doc->{dc_id},
-                id => $doc->{id},
-                reference => $doc->{file_reference},
-                access_hash => $doc->{access_hash},
-                cb => sub {
-                    $self->event( 'fetch', msg_id => $mesg->{id}, name => $filename, @_ )
-                }
-            );
+            $self->_handle_document($doc, msg_id => $mesg->{id});
         }
         elsif ( $mesg->{media}->isa('Telegram::MessageMediaPhoto') ) {
             my $photo = $mesg->{media}{photo};
-            for my $sz ( @{$photo->{sizes}} ) {
-                my $filename = $self->{_storage}{files};
-                $filename .= $self->{_config}{home_dc} .'_'. $photo->{id};
-                $filename .= '_'. $sz->{w} .'x'. $sz->{h};
-                
-                $self->fetch_file(
-                    dst => $filename,
-                    type => 'file',
-                    dc => $sz->{location}{dc_id},
-                    volume_id => $sz->{location}{volume_id},
-                    local_id => $sz->{location}{local_id},
-                    secret => $sz->{location}{secret},
-                    reference => $sz->{location}{file_reference},
-                    access_hash => $photo->{access_hash},
-                    cb => sub {
-                        $self->event( 'fetch', msg_id => $mesg->{id}, name => $filename, @_ )
-                    }
-                );
-            }
+            $self->_handle_photo($photo, msg_id => $mesg->{id} );
         }
     }
     AE::log trace => "message: ". Dumper($mesg);
+}
+
+sub _handle_document
+{
+    my ($self, $doc, %param) = @_;
+
+    my $filename = $self->{_storage}{files};
+    $filename .= $doc->{dc_id} .'_'. $doc->{id};
+
+    $self->fetch_file(
+        dst => $filename,
+        type => 'doc',
+        dc => $doc->{dc_id},
+        id => $doc->{id},
+        reference => $doc->{file_reference},
+        access_hash => $doc->{access_hash},
+        cb => sub {
+            $self->event( 'fetch', name => $filename, %param, @_ )
+        }
+    );
+}
+
+sub _handle_photo
+{
+    my ($self, $photo, %param) = @_;
+
+    for my $sz ( @{$photo->{sizes}} ) {
+        my $filename = $self->{_storage}{files};
+        $filename .= $self->{_config}{home_dc} .'_'. $photo->{id};
+        $filename .= '_'. $sz->{w} .'x'. $sz->{h};
+
+        $self->fetch_file(
+            dst => $filename,
+            type => 'file',
+            dc => $sz->{location}{dc_id},
+            volume_id => $sz->{location}{volume_id},
+            local_id => $sz->{location}{local_id},
+            secret => $sz->{location}{secret},
+            reference => $sz->{location}{file_reference},
+            access_hash => $photo->{access_hash},
+            cb => sub {
+                $self->event( 'fetch', name => $filename, %param, @_ )
+            }
+        );
+    }
 }
 
 sub _recursive_input_access_fix
@@ -292,15 +389,18 @@ sub _recursive_input_access_fix
     return 1;
 }
 
+# when fix_input option is set to 1 access_hash from peer cache
+# is added recursively to every InputPeer
 sub invoke
 {
     my ($self, $query, $cb, %param) = @_;
 
-    my $fix_input = $param{fix_input} // 0;
+    my $fix_input = delete($param{fix_input}) // 0;
     if ($fix_input) {
         $self->_recursive_input_access_fix($query) or return;
     }
-    $self->{_tg}->invoke($query, $cb);
+    # XXX delete noqueue (don't allow it for user) here?
+    $self->{_tg}->invoke($query, $cb, %param);
 }
 
 sub auth
@@ -309,7 +409,7 @@ sub auth
 
     if ($arg{phone}) {
         $self->{_phone} = $arg{phone};
-        my %param = $self->{_storage}->tg_param;
+        my %param = %{ $self->{_storage}->get('config') };
         $self->{_tg}->invoke(
             Telegram::Auth::SendCode->new(
                 phone_number => $arg{phone},
@@ -332,7 +432,7 @@ sub auth
                     $arg{cb}->(error => 'UNKNOWN') if defined $arg{cb};
                 }
             },
-            1
+            noqueue => 1
         );
     }
     elsif ($arg{code}) {
@@ -356,7 +456,7 @@ sub auth
                         say Dumper $res;
                     }
                 },
-                1
+                noqueue => 1
             );
         }
         else {
@@ -387,7 +487,7 @@ sub auth
                         say Dumper $res;
                     }
                 },
-                1
+                noqueue => 1
             );
         }
     }
@@ -427,10 +527,10 @@ sub auth
                             say Dumper $res;
                         }
                     },
-                    1
+                    noqueue => 1
                 );
             },
-            1
+            noqueue => 1
         );
     }
 }
@@ -461,8 +561,8 @@ sub fetch_file
 
     my $roam = $self->_spawn_tg( $file{dc}, 0 );
     $roam->start;
-
-    if ( $file{dc} != $self->{_config}{home_dc} ) {
+    # TODO use cached exported auth and reuse by session manager instead of $roam
+    if ( $file{dc} != $self->{home_dc} ) {
         $self->{_tg}->invoke( 
             Telegram::Auth::ExportAuthorization->new( dc_id => $file{dc} ),
             sub {
@@ -471,6 +571,8 @@ sub fetch_file
                     $file{cb}->( error => $auth->{error_message} );
                 }
                 else {
+                    my $adc = $self->{_storage}-get(auth => "/dc");
+                    $adc->{$file{dc}}->{exported} = $auth;
                     $roam->invoke(
                         Telegram::Auth::ImportAuthorization->new(
                             id => $auth->{id},
@@ -596,8 +698,6 @@ sub send_text_message
             $arg{$_} ? ( $_ => $arg{$_} ) : ()
         } qw(no_webpage silent background clear_draft reply_to_msg_id entities)
     );
-    my $users = $self->{session}{users};
-    my $chats = $self->{session}{chats};
 
     $msg->{message} = $arg{message};    # TODO check utf8
     $msg->{random_id} = int(rand(65536));

--- a/Teleperl/Storage.pm
+++ b/Teleperl/Storage.pm
@@ -2,17 +2,296 @@ use Modern::Perl;
 
 package Teleperl::Storage;
 
+=head1 NAME
+
+Teleperl::Storage - handle temporary and permanent storage for both mutable
+and read-only (configuration) state for entire library.
+
+=head1 SYNOPSIS
+
+    my $storobj = Teleperl::Storage->new( dir => $opts->{sessdir}, %params );
+    my $tg = Teleperl->new( storage => $storobj, %otheropts );
+
+=head1 DESCRIPTION
+
+This is unified storage object allowing different backends. There are, let us say, three size categories of data in Teleperl (Telegram): small, medium and large.
+
+Small is an absolute minimum required for running, e.g. auth keys, cache of user id <-> name correspondence, update counters and times, etc.
+
+Medium-sized data is what could be re-requested from server if needed but interactive application would want to cache it for responsiveness and performance reasons: message texts, webpage instant previews, etc. This could go into e.g. SQLite database.
+
+Large-sized data is what will be stored value-per-file, that is - files. E.g. stickers, images posted to chats, user profile photos, etc.
+
+Of course distinction is somewhat blurred and is up to application author. Teleperl is a library and could be used for GUI interactive clients, command-line apps, bots, gateways to other IM systems, and so on; in the former case, author may want to put small files like user profile photos directly to DB. in the latter cases, author may choose to avoid file storage completely and do it in-memory only.
+
+Thus, a more granular manner is used. Within C<Teleperl::Storage> for each type of data a B<namespace> is "mounted", each with it's own backend storage instance type and settings (e.g. a file or table name). A I<namespace> is just a non-interpreted string (you may put there slashes or colons for your module name, for example), corresponding to Perl hash reference - a data tree. Later, an entire namespace or it's subtree (down to a single value) could be retrieved by C<get()> call in aplication.
+
+In a minimal implementation, only L<Storable> and L<Config::Tiny> are supported as disk backends. Currently you'll need to subclass C<Teleperl::Storage> to add more storage types.
+
+=head2 get( $namespace, $parameter = "", %options )
+
+    $href = $stor->get( 'main' );
+    $dc   = $stor->get( 'config', 'dc' ); say $dc->{addr}
+    $int  = $stor->get( 'config', 'proxy/port' );
+    $str  = $stor->get( 'mtproto', '/dc/*[2]/session/auth_key' );
+
+Return a storage value or subtree: scalar, arrayref, hashref. In list context, all values matched by expresion are returned, in scalar context, only the first one.
+
+Arguments:
+
+=over 4
+
+=item $namespace
+
+Where to look for data. Some storage backends may interpret it as a relative path to file on disk (with slashes, without extension), for others it's just an arbitrary string.
+
+=item $parameter
+
+If empty, the entire hash of this C<$namespace> is returned. Otherwise, it specifies what part of C<$namespace> to get. For most backend storage types (all of default implementation), this is L<Data::DPath> expresion, see there for description of the language. Some backends, especially using L<tie()|perlfunc/tie VARIABLE,CLASSNAME,LIST>'d hashes (e.g. for SQL tables), may choose to support something more simple.
+
+=item %options
+
+May be empty. Currently only one key defined, C<wantref> for returning references to matched points in data structure (internally, this uses C<dpathr> instead of C<dpath>). This is useful if you are working with last level of tree and e.g. want to change leaf scalars - otherwise, a copies would be returned. Unneeded for intermediate levels where substructure is itself a HASHREF or ARRAYREF, so members will be changeable.
+
+=back
+
+=head2 new( [%opts] )
+
+    $stor = Teleperl::Storage->new( dir => './cli', configfile => 'my.ini' );
+
+    $stor = Teleperl::Storage->new(
+        cfcolor     => $cmdline_opts->{colorconfig},
+        spacespec   => {
+            messages    => [ "memory" ],
+            chatwho     => [ "Storable", 'chat_members.dat', 0 ],
+            onlinehist  => [ "Storable", 'last$1.dat', 1 ],
+            filters     => [ "Config::Tiny", 'filters.ini' ],
+            colors      => [ "Config::Tiny", "term.ini", { arg => 'cfcolor' } ]
+        } );
+
+    $stor->new(spacespec => { myplugin => [ "memory" ] });
+
+Initialize storage by reading from disk into Perl data structures. If called on already initialized object, then adds new namespace to list of already loaded ones (useful for plugins after the application start). The following arguments are supported:
+
+=over
+
+=item dir
+
+Directory, relative to which will be other files. Defaults to '.' (surrent directory).
+
+=item files
+
+Directory, under C<dir>, where auto-fetched (cached) files will be created.
+
+B<I<XXX> NOTE> this param/implementation is temporary and will be changed in future.
+
+=item spacespec
+
+A hashref, which is spliced into pre-defined namespaces specification, to override them or add new namespaces. The keys are namespace names, the values are array refs, of which the first element is type of storage (name of storage backend class), and others are arguments for this backend, describing file name and other options. In case C<new()> called on already initialized object, namespace name may not be one of previously used.
+
+The currently supported storage types are:
+
+=over
+
+=item memory
+
+Initialized to empty hash ref C<{}>, does nothing - discarded instead of saving. For pure in-memory temporary storage of data shared between different modules.
+
+=item Storable
+
+Uses L<Storable>. The second argument is file name, the third is flag for C<save()> method - whether to store this by default. For file name, additional processing is done: the substring 'C<$1>' is replaced with namespace name itself.
+
+=item Config::Tiny
+
+Read-only storage. The second argument is a configuration file name used by default. If third argument is a hashref, it's C<arg> key is used as a name of that key argument to C<new()> - to be used as a file name instead of default.
+
+=back
+
+=item configfile
+
+=item ...others from spec
+
+As seen from C<spacespec>, backends could be supplied name of argument to C<new()> - by default this allows C<configfile> to be passed for C<config> namespace, without typing boring spec to C<new()>.
+
+=back
+
+=head2 save( [%which] )
+
+Save data from memory to disk. An arguments may be provided, as "C<< $namespace => boolean >>" pairs, specifying what to save. Defaults from C<new()> will be used for not provided namespaces.
+
+=head1 STRUCTURE OF MINIMAL DATA, TERMINOLOGY
+
+These are: peer cache (id / @username / first/last name correspondence), update cache (one integer per chat) and the most pain - session data.
+
+Unfortunately, Telegram is not consistent with terminology. There are two different entities called I<session> - first, what you see in UI of official client listing "current sessions", where each session corresponds to entire device / OS. Second, is an I<MTProto session> which has sequence number of message in it and can persist between TCP conections. There could be multiple MTProto sessions running at the same time, e.g. to speed up file downloads.
+
+Between those two I<sessions>, sits an I<authorization>. It could be said that I<UI session> is the same as I<authorization> in degenerate case, but alas, things are more comlicated. See:
+
+=over
+
+=item *
+User on a new device first generates I<auth_key> and bounds it to account via e.g. SMS, thus an I<authorization> has been created.
+
+=item *
+This had happened inside first I<MTProto session>, which has C<session_id> in it.
+
+=item *
+At this step, combination of I<authorization> and C<session_id> could be called I<instance> - which it is in some clients and was in Teleperl at some time.
+
+=item *
+Then, client could open B<multiple> I<MTProto sessions> under the same I<auth_key> - to the same DC.
+
+=item *
+Then at one step, client needs to request file from I<another DC> - and new I<auth_key> will be generated for this DC!
+
+=item *
+To help in the fact this is not new user but same I<authorization> (I<UI session>), client uses API calls C<auth.exportAuthorization> in I<home DC> and C<auth.importAuthorization> this in new DC.
+
+=item *
+There could be multiple I<MTProto sessions> (each with own C<session_id>) to new DC under B<it's> I<auth_key>.
+
+=item *
+Moreover, client may choose to do Perfect Forward Secrecy. The every I<auth_key> above was B<permanent> key - per DC - and client may call C<auth.bindTempAuthKey> for using I<temporary> I<auth_key> - again, only one I<temp_auth_key> per DC, same for all I<MTProto sessions> to that DC.
+
+=back
+
+Note that I<salt> (and future salts) are also only one per I<auth_key> and shared between multiple I<MTProto sessions> to same DC.
+
+The DC where user accont data stored and from where event updates go, is called I<home DC>, and other DCs, which are used only for file requests, are called in Teleperl I<roaming DC>. But due to the fact Telegram server occasionally may move user data to another home DC specifying C<USER_MIGRATE_X> error, at the storage level all DCs and sessions are equal, and one variable distinguishes home DC (and main (updates) session id) outside.
+
+Thus, structure main two files are:
+
+=head2 auth.dat
+
+Contains sensitive crypto information (keys, salts), should be under C<chmod 600>. It's keys are:
+
+=over
+
+=item dc
+
+Hash with per-DC info. It should be an array, but due to MTProxy shifted numbers are possible. So keys are DC number, values are hashes:
+
+=over
+
+=item permkey
+
+Main key hash, contains C<auth_key>, C<auth_key_id>, C<auth_key_aux> fields.
+
+=item tempkey
+
+Same structure as I<permkey>, used if Perfect Forward Secrecy is enabled
+
+=item salt
+
+(current) C<salt> (I<XXX it seems salt is shared between tempkey and permkey, need to check>)
+
+=item future_salts
+
+An L<MTProto::FutureSalts> object with time interval for new salts, it contains it's own request time inside as C<now> member. Last time this DC was exchanged messages (may be used for changing salts) may be found in C<session.dat>.
+
+=item exported
+
+Cached L<Telegram::Auth::ExportedAuthorization> for this DC, if not home and was ever requested.
+
+=back
+
+=item other top-level keys may be added later for e.g. secret chats, passports, etc.
+
+=back
+
+=head2 session.dat
+
+Carries data pertaining to overall I<UI session> and I<MTProto sessions>. Top-level keys of hash are:
+
+=over
+
+=item self_id
+
+User id of account owner, just for convenience.
+
+=item home_dc
+
+Number of home DC.
+
+=item main_session_id
+
+May contain C<session_id> of main (with updates) connection (on home DC).
+
+=item sessions
+
+Hash where key is DC numer, value is array of per-DC I<MTProto sessions>. Array elements are per-session hashes which keys are:
+
+=over
+
+=item I<id>
+8 random bytes, MTProto session_id
+
+=item I<seq>
+MTProto message sequence number in session
+
+=item I<time>
+when last bytes were received from socket, for purging stale sessions and salts
+
+=back
+
+=item config
+
+L<Telegram::Config> object. As it may change frequently, contains it's own time in C<date> field.
+
+=item cdnconfig
+
+L<Telegram::CdnConfig> object.
+
+=item cdnconfig_time
+
+Unix time_t of when C<cdnconfig> was received (updated).
+
+=back
+
+=cut
+
 use Config::Tiny;
-use Storable qw( store retrieve freeze thaw );
+use Storable qw( nstore retrieve freeze thaw );
+use File::Spec;
+use Data::DPath qw(dpath dpathr);
+$Data::DPath::USE_SAFE = 0; # or it will not see our classes O_o
+
 use Data::Dumper;
 
-use constant {
-    SESSION_FILE => 'session.dat',
-    AUTH_FILE => 'auth.dat',
-    CACHE_FILE => 'cache.dat',
-    UPDATES_FILE => 'upd.dat',
-    TCONF_FILE => 'tconf.dat',
+my $DEF_AUTH = {
+    dc => {
+        '1' => { permkey => {}, tempkey => {}, salt => '', future_salts => {}, },
+        '2' => { permkey => {}, tempkey => {}, salt => '', future_salts => {}, },
+        '3' => { permkey => {}, tempkey => {}, salt => '', future_salts => {}, },
+        '4' => { permkey => {}, tempkey => {}, salt => '', future_salts => {}, },
+        '5' => { permkey => {}, tempkey => {}, salt => '', future_salts => {}, },
+    },
 };
+
+my $DEF_SESS = {
+        self_id         => undef,
+        home_dc         => undef,
+        main_session_id => '',
+        sessions        => {
+            '1' => [],
+            '2' => [],
+            '3' => [],
+            '4' => [],
+            '5' => [],
+        },
+        config          => {},
+        cdnconfig       => {},
+        cdnconfig_time  => 0,
+};
+
+our %DEFAULT_SPEC = (
+    session     => [ 'Storable', 'session.dat', 1,    0, \&DEF_SESS ],
+    auth        => [ 'Storable', 'auth.dat',    0, 0600, \&DEF_AUTH ],
+    cache       => [ 'Storable', '$1.dat',      1       ],
+    update_state=> [ 'Storable', 'upd.dat',     1       ],
+    config      => [ 'Config::Tiny', "teleperl.conf", { arg => 'configfile' }],
+    files       => [ "memory" ],
+);
 
 sub new
 {
@@ -20,30 +299,78 @@ sub new
 
     $self = bless( {}, $self ) unless ref $self;
 
-    my $prefix = $arg{dir} // '.';
-    $prefix .= '/';
+    my $arg_spacespec = delete $arg{spacespec};
+    my $prefix = delete($arg{dir}) // '.';
+    $self->{_dir} = $prefix unless $self->{_dir};
 
-    $self->{_dir} = $arg{dir};
-    $self->{_file}{session} = $prefix . SESSION_FILE;
-    $self->{_file}{auth} = $prefix . AUTH_FILE;
-    $self->{_file}{cache} = $prefix . CACHE_FILE;
-    $self->{_file}{tconf} = $prefix . TCONF_FILE;
-    $self->{_file}{update_state} = $prefix . UPDATES_FILE;
+    # support adding new namespaces after creation
+    my %spec = (
+        exists $self->{_spec} ? () : %DEFAULT_SPEC,
+        defined $arg_spacespec ? %$arg_spacespec : (),
+    );
+    # but changing already loaded spaces is currently not supported
+    if (defined $self->{_spec}) {
+        delete $spec{$_}, warn("storage $_ already exists!")
+            for keys %{ $self->{_spec} };
+        $self->{_spec} = {
+            %{ $self->{_spec} },
+            %spec,
+        } if %spec;
+    }
+    else {
+        $self->{_spec} = { %spec };
+    }
 
-    for my $state (qw/session auth cache update_state tconf/) {
-        if (-e $self->{_file}{$state}) {
-            $self->{$state} = retrieve $self->{_file}{$state}
+    for my $state (keys %spec) {
+        $self->{$state} = {};
+        my $instance = $spec{$state};
+        my $backend = shift @$instance;
+        my $handler = {
+            'Storable'      => sub {
+                my @inst = @{ shift(@_) };
+                my %args = @_;
+                my $file = $inst[0];
+                if ($file =~ /\$1/) {
+                    $file =~ s/\$1/$state/;
+                }
+                $file = File::Spec->catfile($prefix, $file);
+
+                if (-e $file) {
+                    $self->{$state} = retrieve $file;
+                }
+                elsif (my $defaults = $inst[3]) {
+                    $self->{$state} = $inst[3];
+                }
+              },
+            'Config::Tiny'  => sub {
+                my @inst = @{ shift(@_) };
+                my %args = @_;
+                my $file = $inst[0];
+                if (defined $inst[1] and ref $inst[1] eq 'HASH') {
+                    my $arg = $inst[1]->{arg};
+                    $file = $args{$arg} if defined $arg;
+                }
+                $file = File::Spec->catfile($prefix, $file);
+
+                $self->{$state} = Config::Tiny->read($file);
+              },
+            memory => sub { 1 },
+        }->{$backend};
+        if ($backend) {
+            $backend->($instance, %arg);
         }
         else {
-            $self->{$state} = {}
+            die "Unsupported backend storage '$backend'";
         }
     }
 
+    # XXX to be deprecated
     $self->{files} = $prefix . ( $arg{files} // 'file_cache/' );
     if ( $self->{files} =~ m@/$@ ) {
         mkdir $self->{files} unless -d $self->{files}
     }
-    $self->{config} = Config::Tiny->read("teleperl.conf");
+
+    $self->_migrate2019fall() unless $self->{_migrated};
 
     return $self;
 }
@@ -53,48 +380,147 @@ sub save
     my $self = shift;
     my %flags = @_;
 
-    $flags{session} = 0 unless defined $flags{session};
-    $flags{auth} = 1 unless defined $flags{auth};
-    $flags{cache} = 1 unless defined $flags{cache};
-    $flags{tconf} = 1 unless defined $flags{tconf};
-    $flags{update_state} = 0 unless defined $flags{update_state};
-
     mkdir $self->{_dir} unless -d $self->{_dir};
+    my $prefix = $self->{_dir};
 
-    for my $state (qw/session auth cache update_state tconf/) {
-        store ( $self->{$state}, $self->{_file}{$state} ) 
+    for my $state (keys %{ $self->{_spec} }) {
+        my @instance = @{ $self->{_spec}{$state} };
+        my $backend = shift @instance;
+
+        next unless $backend eq 'Storable';
+
+        my $file = $instance[0];
+
+        if ($file =~ /\$1/) {
+            $file =~ s/\$1/$state/;
+        }
+        $file = File::Spec->catfile($prefix, $file);
+        $flags{$state} = $instance[1] unless defined $flags{$state};
+
+        nstore ( $self->{$state}, $file ) 
             if $flags{$state} and defined $self->{$state};
+
+        if (my $perm = $instance[2]) {
+            chmod $perm, $file;
+        }
     }
 }
 
-sub tg_param
+sub get
 {
-    %{shift->{config}}
+    my ($self, $namespace, $parameter, %options) = @_;
+
+    return $self->{$namespace} unless $parameter;
+
+    my $filter = $options{wantref}
+        ? dpathr($parameter)
+        : dpath ($parameter);
+
+    return wantarray
+        ? $filter->match( $self->{$namespace})
+        : $filter->matchr($self->{$namespace})->[0];
 }
 
-sub mt_session
+# XXX remove in December, until that add here when formats change
+sub _migrate2019fall
 {
-    shift->{session}
-}
+    my $self = shift;
 
-sub mt_auth
-{
-    shift->{auth}
-}
+    ## from 9c67c3eb96   Sep 06
+    # handle old mtp session
+    if ($self->{session}{mtproto}{session_id}) {
+        my $instance = {};
+        my @instance_keys = qw(auth_key auth_key_id auth_key_aux salt);
+        my $session = {};
+        my $mts = $self->{session}{mtproto};
 
-sub upd_state
-{
-    shift->{update_state}
-}
+        @$instance{@instance_keys} = @$mts{@instance_keys};
+        $session->{id} = $mts->{session_id};
+        $session->{seq} = $mts->{seq};
 
-sub peer_cache
-{
-    shift->{cache}
-}
+        $self->{session}{mtproto}{instance} = $instance;
+        $self->{session}{mtproto}{session} = $session;
 
-sub config
-{
-    shift->{tconf}
+        delete $self->{session}{mtproto}{session_id};
+    }
+
+    ## from bdc1c99b31   Sep 24 -> four files
+    if ($self->{session}{update_state}) {
+        $self->{update_state} = delete $self->{session}{update_state};
+    }
+    if ($self->{session}{users}) {
+        $self->{cache}{users} = delete $self->{session}{users};
+    }
+    if ($self->{session}{chats}) {
+        $self->{cache}{chats} = delete $self->{session}{chats};
+    }
+    $self->{cache}{self_id} = $self->{session}{self_id}
+        if $self->{session}{self_id} and not $self->{cache}{self_id};
+    if ($self->{session}{mtproto}) {
+        $self->{auth} = delete $self->{session}{mtproto}{instance};
+        my $mtsession = delete $self->{session}{mtproto}{session};
+        $self->{session} = {
+            %{ $self->{session} },
+            %$mtsession,
+        };
+        delete $self->{session}{mtproto};
+    }
+
+    ## from 1fe6cd374b   Oct 05 -> MTProto: instance -> keys
+    # but nothing changed at backend
+
+    ## Oct 08 - new per-DC (hopefully) stable structure
+    # XXX need to know home_dc for proper convert! so may be need to
+    # run two times, first we'll get Config, second we'll convert
+    # XXX do guesses
+    if (my @adcs = grep { /^\d+$/ } keys %{ $self->{auth} }) {
+        $self->{session}{home_dc} = shift @adcs
+            if not $self->{session}{home_dc} and scalar(@adcs) == 1;
+    }
+    $self->{session}{home_dc} = $ENV{TELEPERL_HOME_DC} if not $self->{session}{home_dc};
+    $self->{session}{home_dc} = 2
+        if not $self->{session}{home_dc} && $self->{config}{user}{phone} =~ /^\+7/;
+    if (not $self->{session}{home_dc}) {
+        $self->{session}{home_dc} = undef;
+        die "comment this & set DC config to convert!";
+    }
+    if ($self->{session}{id}) {
+        my $home_dc = delete $self->{session}{home_dc};
+        my $config  = delete $self->{session}{config} // {};
+        my %mtp_sess = %{ $self->{session} };
+        my %instance = %{ $self->{auth} };
+        my $salt = delete $instance{salt};
+        delete $mtp_sess{home_dc};
+        delete $mtp_sess{self_id};
+        for (grep { /^\d+$/ } keys %{ $self->{auth} }) {
+            $self->{auth}{dc}{$_}{permkey} = delete $self->{auth}{$_};
+        }
+        $self->{auth}{dc}{$home_dc} = {
+                permkey => {
+                    %instance,
+                },
+                tempkey => {},
+                salt    => $salt,
+                future_salts => {},
+            } if $home_dc;
+        $self->{session} = {
+            self_id         => $self->{cache}{self_id},
+            home_dc         => $home_dc,
+            main_session_id => $mtp_sess{id},
+            sessions        => {
+                qq{$home_dc} => [
+                    { %mtp_sess, time => 1570499041 },
+                    { id => 'nonexist', seq => 0, time => 123 },
+                ],
+            },
+            config          => $config,
+            cdnconfig       => {},
+            cdnconfig_time  => 0,
+        };
+    }
+
+    # add new farts here
+    $self->{_migrated} = 20191010;
 }
 
 1;


### PR DESCRIPTION
After 'new-teleperl' branch was renamed to 'master', some features have
been lost, restore them; add other features such as DPath expressions
for storage and (new) filters and future salts to MTProto.

Still more work in next parts, including e.g. to bring other tools
(e.g. GUI) to work with new API.