### PR TITLE
Enchance TL encoding/decoding/validation; fix small bugs

### DIFF
--- a/ClifTg.pm
+++ b/ClifTg.pm
@@ -11,6 +11,12 @@ use AnyEvent::Impl::Perl;
 use AnyEvent;
 use AnyEvent::Log;
 
+# XXX CLI::Framework uses Class::Inspector which conflicts with Safe.pm
+# by going to infinite loop on init (subclasses() call); and we still
+# disable Safe later in # Data::DPath, so hack is here
+# (for reference, it worked on 5.20 with Safe 2.37 and Data::DPath::USE_SAFE=0)
+{ package Safe; sub new { bless {}, 'Safe' } sub AUTOLOAD {1 } }
+
 use Teleperl;
 use Teleperl::Storage;
 
@@ -54,7 +60,7 @@ sub init {
     install_AE_log_crutch();
 
     my $stor = Teleperl::Storage->new(
-        dir         => $opts->{session}.
+        dir         => $opts->{session},
         configfile  => $opts->config
     );
     $app->cache->set( 'storage' => $stor );

--- a/ClifTg.pm
+++ b/ClifTg.pm
@@ -15,7 +15,7 @@ use AnyEvent::Log;
 # by going to infinite loop on init (subclasses() call); and we still
 # disable Safe later in # Data::DPath, so hack is here
 # (for reference, it worked on 5.20 with Safe 2.37 and Data::DPath::USE_SAFE=0)
-{ package Safe; sub new { bless {}, 'Safe' } sub AUTOLOAD {1 } }
+BEGIN { { package Safe; sub new { bless {}, 'Safe' } sub AUTOLOAD {1 } } }
 
 use Teleperl;
 use Teleperl::Storage;

--- a/ClifTg.pm
+++ b/ClifTg.pm
@@ -15,7 +15,12 @@ use AnyEvent::Log;
 # by going to infinite loop on init (subclasses() call); and we still
 # disable Safe later in # Data::DPath, so hack is here
 # (for reference, it worked on 5.20 with Safe 2.37 and Data::DPath::USE_SAFE=0)
-BEGIN { { package Safe; sub new { bless {}, 'Safe' } sub AUTOLOAD {1 } } }
+BEGIN {
+    { package Safe; our $VERSION = 'fake'; sub new { bless {}, 'Safe' }
+      sub AUTOLOAD {1}
+    }
+    $INC{'Safe.pm'} = 1;
+}
 
 use Teleperl;
 use Teleperl::Storage;

--- a/MTProto.pm
+++ b/MTProto.pm
@@ -757,11 +757,14 @@ sub _handle_msg
         }
         elsif ($m->{object}->isa('MTProto::MsgDetailedInfoABC')) {
             $self->event( error => bless(
-                { error_message =>"Unhandled MsgDetailedInfo" },
+                {
+                    error_message =>"Unhandled MsgDetailedInfo",
+                    original_message => $m->{object}
+                },
                 'MTProto::Error'
                 )
             );
-            $self->_state('fatal');
+            AE::log error => "implement me! " .Dumper($m->{object});
             return;
         }
         else {

--- a/MTProto.pm
+++ b/MTProto.pm
@@ -221,7 +221,7 @@ sub start_session
 
     if (defined $self->{dcinstance}{permkey}{auth_key}) {
         my $fs = $self->{dcinstance}{future_salts};
-        if (defined $fs and $fs->isa('MTProto::FutureSalts')) {
+        if (defined $fs and ref $fs eq 'MTProto::FutureSalts') {
             for my $fusalt (@{ $fs->{salts} }) {
                 if ($fusalt->{valid_since} < AE::now and
                     $fusalt->{valid_until} > AE::now

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Pure perl mtproto/telergam client library
 - Parse::Yapp
 - Math::Prime::Util
 - PBKDF2::Tiny
+- Params::Validate if app examples (their depends) are not used
+- Types::Serialiser (formerly part of CBOR::XS, unifies bools with JSON::*)
 
 For both interactive application's examples:
 - Getopt::Long::Descriptive

--- a/TL/Object.pm
+++ b/TL/Object.pm
@@ -77,23 +77,23 @@ sub _val_spec
             }
             else {
                 $TYPE{type} = SCALAR;
+                # XXX do more proper checks, mb by 'callbacks'
+                my %valtype = (
+                    string => { },
+                    bytes  => { },
+                    int    => { regex => qr/^\s*[-+]?\d{1,10}\s*$/, $DEFAULT_NUMBERS ? (default => 0) : () },
+                    nat    => { regex => qr/^\s*\d+\s*$/          , $DEFAULT_NUMBERS ? (default => 0) : () },
+                    long   => { regex => qr/^\s*[-+]?\d{1,19}\s*$/, $DEFAULT_NUMBERS ? (default => 0) : () },
+                    int128 => { },   # XXX
+                    int256 => { },   # XXX
+                    double => {
+                        regex => qr/^\s*[-+]?(\d+|\.\d+|\d+\.\d*)([eE][-+]?\d+)?\s*$/,
+                        $DEFAULT_NUMBERS ? (default => 0) : ()
+                    },
+                    date	=> { },   # XXX wat? haven't seen such in schema
+                );
+                %TYPE = ( %TYPE, %{ $valtype{$t} } );
             }
-            # XXX do more proper checks, mb by 'callbacks'
-            my %valtype = (
-                string	=> { },
-                bytes	=> { },
-                int	=> { regex => qr/^\s*[-+]?\d{1,10}\s*$/, $DEFAULT_NUMBERS ? (default => 0) : () },
-                nat	=> { regex => qr/^\s*\d+\s*$/          , $DEFAULT_NUMBERS ? (default => 0) : () },
-                long	=> { regex => qr/^\s*[-+]?\d{1,19}\s*$/, $DEFAULT_NUMBERS ? (default => 0) : () },
-                int128	=> { },   # XXX
-                int256	=> { },   # XXX
-                double	=> {
-                    regex => qr/^\s*[-+]?(\d+|\.\d+|\d+\.\d*)([eE][-+]?\d+)?\s*$/,
-                    $DEFAULT_NUMBERS ? (default => 0) : ()
-                },
-                date	=> { },   # XXX wat? haven't seen such in schema
-            );
-            %TYPE = ( %TYPE, %{ $valtype{$t} } );
         }
         else {
             my $baspkg = delete $TYPE{type};
@@ -121,7 +121,7 @@ sub validate
         stack_skip => 1,
         # on_fail     => sub { # default is 'confess', probably enough for us
     );
-    $self->{$_} = $p{$_} for grep { exists $spec->{$_}{default} } keys %$spec;
+    $self->{$_} = $p{$_} for grep { ref $spec->{$_} && exists $spec->{$_}{default} } keys %$spec;
 }
 
 sub THAW

--- a/TL/Object.pm
+++ b/TL/Object.pm
@@ -65,18 +65,18 @@ sub _val_spec
         my $v = delete $TYPE{vector};
         # XXX alas, Params::Validate has no easy way for array element type
         if ($v) {
-            $TYPE{type} = 'ARRAYREF';
+            $TYPE{type} = ARRAYREF;
         }
         elsif ($b) {
             my $t = delete $TYPE{type};
             if ($t eq 'true' or $t eq 'Bool') {
-                $TYPE{type} = 'BOOLEAN';
+                $TYPE{type} = BOOLEAN;
             }
             elsif ($t eq 'Object') {
-                $TYPE{type} = uc $t;
+                $TYPE{type} = OBJECT;
             }
             else {
-                $TYPE{type} = 'SCALAR';
+                $TYPE{type} = SCALAR;
             }
             # XXX do more proper checks, mb by 'callbacks'
             my %valtype = (

--- a/TL/Object.pm
+++ b/TL/Object.pm
@@ -95,7 +95,7 @@ sub _val_spec
                 date   => { },   # XXX wat? haven't ever seen such in schema
                 true   => { default => 0 },
                 Bool   => { $DEFAULT_NUMBERS ? (default => 0) : () }, # XXX check if ref?
-                Object => { isa => __PACKAGE__ },
+                Object => { } # isa => __PACKAGE__ TODO but Result may be Bool, should be thought later
             );
             %TYPE = ( %TYPE, %{ $valtype{$t} } );
         }

--- a/TeleCrypt/AES.pm
+++ b/TeleCrypt/AES.pm
@@ -1,4 +1,4 @@
-package Teleperl::Util;
+package TeleCrypt::AES;
 
 use Modern::Perl;
 use base 'Exporter';

--- a/Telegram.pm
+++ b/Telegram.pm
@@ -24,6 +24,7 @@ use AnyEvent;
 
 use MTProto;
 use MTProto::Ping;
+use MTProto::GetFutureSalts;
 
 ## Telegram API
 
@@ -432,7 +433,7 @@ sub _run_filters
 {
     my ($self, $table, $data) = @_;
 
-    for my $rule ($self->{_filters}{$table}) {
+    for my $rule (@{ $self->{_filters}{$table} }) {
         if (my @res = $rule->{filter}->match($data)) {
             $self->event( $table . '_' . $rule->{name}, @res );
         }

--- a/Teleperl.pm
+++ b/Teleperl.pm
@@ -148,7 +148,7 @@ sub _spawn_tg
 
     my %param = %{ $self->{_storage}->get('config') };
 
-    if ($dc) {
+    if ($dc && !($main && %{$self->{_config}}==0)) { # if ($dc) XXX tmp migrate when home_dc known but Getconfig not yet
         my @options = grep { $_->{id} == $dc } @{$self->{_config}{dc_options}};
 
         if (defined $param{proxy}) {
@@ -234,7 +234,7 @@ sub _run_filters
 {
     my ($self, $table, $data) = @_;
 
-    for my $rule ($self->{_filters}{$table}) {
+    for my $rule (@{ $self->{_filters}{$table} }) {
         if (my @res = $rule->{filter}->match($data)) {
             $self->event( $table . '_' . $rule->{name}, @res );
         }
@@ -571,7 +571,7 @@ sub fetch_file
                     $file{cb}->( error => $auth->{error_message} );
                 }
                 else {
-                    my $adc = $self->{_storage}-get(auth => "/dc");
+                    my $adc = $self->{_storage}->get(auth => "/dc");
                     $adc->{$file{dc}}->{exported} = $auth;
                     $roam->invoke(
                         Telegram::Auth::ImportAuthorization->new(

--- a/Teleperl/Storage.pm
+++ b/Teleperl/Storage.pm
@@ -356,8 +356,8 @@ sub new
               },
             memory => sub { 1 },
         }->{$backend};
-        if ($backend) {
-            $backend->($instance, %arg);
+        if ($handler) {
+            $handler->($instance, %arg);
         }
         else {
             die "Unsupported backend storage '$backend'";

--- a/tl-gen.pl
+++ b/tl-gen.pl
@@ -210,6 +210,13 @@ for my $type (@types) {
             if (exists $builtin{$arg->{type}{name}} and $arg->{type}{name} ne 'Object') {
                 print $f "  push \@stream, TL::Object::pack_$arg->{type}{name}( \$_ ) for \@{\$self->{$arg->{name}}};\n"
             }
+            elsif ($arg->{type}{name} =~ /^[a-z]/) { # XXX see below in unpack
+                my @bares = grep { $_->{id} eq $arg->{type}{name} } @types;
+                die "bare count for $arg->{type}{name} is not 1" unless @bares == 1;
+                my (undef, $pkg) = pkgname($prefix, $bares[0]->{id});
+                print $f "  BEGIN { require $pkg; }\n";
+                print $f "  push \@stream, $pkg\->pack() for \@{\$self->{$arg->{name}}};\n";
+            }
             else {
                 print $f "  push \@stream, \$_->pack() for \@{\$self->{$arg->{name}}};\n"
             }

--- a/tl-gen.pl
+++ b/tl-gen.pl
@@ -253,6 +253,17 @@ for my $type (@types) {
             if (exists $builtin{$arg->{type}{name}} and $arg->{type}{name} ne 'Object') {
                 print $f "  push \@_v, TL::Object::unpack_$arg->{type}{name}( \$stream ) while (\$_--);\n";
             }
+            elsif ($arg->{type}{name} =~ /^[a-z]/) {
+                # XXX docs: Bare type is a type whose values do not contain a
+                # constructor number, which is implied instead. A bare type
+                # identifier always coincides with the name of the implied
+                # constructor (and therefore, begins with a lowercase letter)
+                my @bares = grep { $_->{id} eq $arg->{type}{name} } @types;
+                die "bare count for $arg->{type}{name} is not 1" unless @bares == 1;
+                my (undef, $pkg) = pkgname($prefix, $bares[0]->{id});
+                print $f " BEGIN { require $pkg; }\n";
+                print $f "  push \@_v, $pkg\->unpack( \$stream ) while \$_--;\n";
+            }
             else {
                 print $f "  push \@_v, TL::Object::unpack_obj( \$stream ) while (\$_--); # $arg->{type}{name}\n";
             }


### PR DESCRIPTION
Improve TL::Object and schema generator by:

* moving `THAW`/`TO_CBOR` to base `TL::Object` thus reducing memory consumption
* adding ability to automatically decode/encode UTF8-strings to/from
  Perl string for `string` type in schema - `bytes` will still be octets.
  Disabled by default, use global `$TL::Object::UTF8_STRINGS = 1` to enable.
* adding ability to do basic type checking on Perl objects with
  `Params::Validate` (already used by CLI dependencies):
  - before sending to server, if `$TL::Object::VALIDATE` bit 0 is set
  - after receiving from server, if `$TL::Object::VALIDATE` bit 1 is set
  - assigning default value (currently just 0) for number types in
    schema in either case above, if `$TL::Object::DEFAULT_NUMBERS` set true.
  This should help to catch mistakes and at the same time, ease
  switching between near schema layers where difference is just in
  mandatory integers usually set to zero anyway.
* some minor improvements

Besides that 2 files, all other changes in this commit are fixes of
small bugs (mainly typos) preventing running, introduced by PRs
3 previous weeks; and workaround for discovered conflict of Class::Inspector
(used by CLI) and Safe.pm (used by Data::DPath) on newer Perls - looks
like hang in loop and eating memory just after `use` of CLI module.